### PR TITLE
fix build

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@
 * ENHANCEMENT: Fix minor things in the documentation, thanks @dawedawe - https://github.com/fsprojects/FAKE/pull/2603
 * ENHANCEMENT: Add missing report types to ReportType, thanks @mcliment - https://github.com/fsprojects/FAKE/pull/2606
 * ENHANCEMENT: Support .net6 runtime assemblies, new Build system, and Legacy Fake Codebase Separation, thanks @yazeedobaid - https://github.com/fsprojects/FAKE/pull/2609
+* BUGFIX: Update Octokit to 0.50 and fix upload assets, thanks @enovales - https://github.com/fsprojects/FAKE/issues/2601
 
 ## 5.20.4 - 2021-03-31
 

--- a/build.fsx
+++ b/build.fsx
@@ -1099,7 +1099,6 @@ Target.create "ReleaseDocs" (fun _ ->
 
     Git.Repository.fullclean "gh-pages"
     Shell.copyRecursive "docs" "gh-pages" true |> printfn "%A"
-    Shell.copyFile "gh-pages" "./Samples/FAKE-Calculator.zip"
     File.writeString false "./gh-pages/CNAME" docsDomain
     Git.Staging.stageAll "gh-pages"
     if not BuildServer.isLocalBuild then

--- a/src/app/Fake.Api.GitHub/GitHub.fs
+++ b/src/app/Fake.Api.GitHub/GitHub.fs
@@ -212,7 +212,7 @@ module GitHub =
             let archiveContents = File.OpenRead(fi.FullName)
             let assetUpload = ReleaseAssetUpload(fi.Name,"application/octet-stream",archiveContents,Nullable timeout)
             
-            let! asset = Async.AwaitTask <| release'.Client.Repository.Release.UploadAsset(release'.Release, assetUpload)
+            let! asset = Async.AwaitTask <| release'.Client.Repository.Release.UploadAsset(release'.Release, assetUpload, Async.DefaultCancellationToken)
             printfn "Uploaded %s" asset.Name
             return release'
         }


### PR DESCRIPTION
### Description

Remove old samples from site deployment and fix in Octockit breaking change

## TODO

Feel free to open the PR and ask for help

- [ ] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [ ] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [ ] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [ ] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [ ] (if new module) the module is in the correct namespace
- [ ] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [ ] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
