### PR TITLE
Fix retrieval of SDK version on .NET 6.0.0

### DIFF
--- a/src/app/Fake.Runtime/SdkAssemblyResolver.fs
+++ b/src/app/Fake.Runtime/SdkAssemblyResolver.fs
@@ -39,7 +39,14 @@ type SdkAssemblyResolver() =
             | false -> systemInstallDir
 
         let dotnet6RuntimeVersion =
+            // See dotnet/runtime#61394
+            let stripBuildInformationIfExists (version: string) =
+                match version.IndexOf("-") with
+                | x when x < 0 -> version
+                | x -> version.Substring(0, x)
+            
             RuntimeInformation.FrameworkDescription.Replace(".NET ", "")
+            |> stripBuildInformationIfExists
 
         Directory.GetFiles(
             dotnet6ReferenceAssembliesPath


### PR DESCRIPTION
Fixes #2618. I'm not sure if a test can be implemented, since we can't enforce values for `RuntimeInformation.FrameworkDescription`.
