### PR TITLE
Fix FAKE template integration tests.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "fake-cli": {
-      "version": "5.21.0-alpha004",
+      "version": "5.21.0",
       "commands": [
         "fake"
       ]

--- a/build.fsx
+++ b/build.fsx
@@ -207,7 +207,7 @@ let version =
                 |> Seq.append [ 0I ]
                 |> Seq.max
             let d = System.DateTime.Now
-            [ PreReleaseSegment.AlphaNumeric ("local-" + (currentVer + 1I).ToString()) ], d.ToString("yyyy-MM-dd-HH-mm")
+            [ PreReleaseSegment.AlphaNumeric ("local." + (currentVer + 1I).ToString()) ], d.ToString("yyyy-MM-dd-HH-mm")
 
     let semVer = SemVer.parse release.NugetVersion
     let prerelease =

--- a/src/test/Fake.DotNet.Cli.IntegrationTests/TemplateTests.fs
+++ b/src/test/Fake.DotNet.Cli.IntegrationTests/TemplateTests.fs
@@ -73,7 +73,7 @@ let timeout = (System.TimeSpan.FromMinutes 10.)
 let runTemplate rootDir kind dependencies dsl =
     Directory.ensure rootDir
     try
-        DotNet.exec (dtntWorkDir rootDir >> redirect()) "new" (sprintf "%s --allow-scripts yes --version 5.16.2-alpha.1304 --bootstrap %s --dependencies %s --dsl %s" templateName (string kind) (string dependencies) (string dsl))   
+        DotNet.exec (dtntWorkDir rootDir >> redirect()) "new" (sprintf "%s --allow-scripts yes --bootstrap %s --dependencies %s --dsl %s" templateName (string kind) (string dependencies) (string dsl))
         |> shouldSucceed "should have run the template successfully"
     with e ->
         if e.Message.Contains "Command succeeded" && 


### PR DESCRIPTION
### Description

Fix FAKE template integration tests. The tests started to fail after the upgrade of FAKE repository to NET 6.0.101.
The template tests were pinned to an old version of FAKE runner and from the logs, it seems that it is not compatible with NET 6
