### PR TITLE
Add known paths for more recent versions of msbuild

### DIFF
--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -135,6 +135,11 @@ module private MSBuildExe =
                                      @"\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
                                      @"\MSBuild\Current\Bin"
                                      @"\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"] }
+        { Version = "16.0"; Paths = [@"\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
+                                     @"\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
+                                     @"\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
+                                     @"\MSBuild\Current\Bin"
+                                     @"\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"] }
         { Version = "15.0"; Paths = [@"\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin"
                                      @"\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin"
                                      @"\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin"

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -130,6 +130,11 @@ module private MSBuildExeFromVsWhere =
 module private MSBuildExe =
   let knownMSBuildEntries =
     [
+        { Version = "17.0"; Paths = [@"\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
+                                     @"\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
+                                     @"\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
+                                     @"\MSBuild\Current\Bin"
+                                     @"\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"] }
         { Version = "15.0"; Paths = [@"\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin"
                                      @"\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin"
                                      @"\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin"


### PR DESCRIPTION
### Description

Since Visual Studio 2017, two 2 major versions were released.
Here is the update to add the known paths for thoses two new versions.

## TODO

Feel free to open the PR and ask for help

- [ ] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [ ] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [ ] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [ ] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [ ] (if new module) the module is in the correct namespace
- [ ] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [ ] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
