### PR TITLE
Resolve symlinks while searching for dotnet

### DIFF
--- a/src/app/Fake.Runtime/SdkAssemblyResolver.fs
+++ b/src/app/Fake.Runtime/SdkAssemblyResolver.fs
@@ -177,7 +177,10 @@ type SdkAssemblyResolver(logLevel:Trace.VerboseLevel) =
             |> Array.tryPick (fun d ->
                 let fi = Path.Combine(d, dotnetBinaryName) |> FileInfo
 
-                resolveFile fi)
+                if fi.Exists then
+                    Some fi
+                else
+                    None)
 
         let tryFindFromDefaultDirs () =
             let windowsPath = $"C:\\Program Files\\dotnet\\{dotnetBinaryName}"
@@ -212,6 +215,7 @@ type SdkAssemblyResolver(logLevel:Trace.VerboseLevel) =
                 tryFindFromEnvVar ()
                 |> Option.orElseWith tryFindFromPATH
                 |> Option.orElseWith tryFindFromDefaultDirs
+                |> Option.bind resolveFile
                 |> Option.map (fun dotnetRoot -> dotnetRoot.Directory.FullName)
         
         let referenceAssembliesPath =

--- a/src/test/Fake.Core.UnitTests/Fake.Core.UnitTests.fsproj
+++ b/src/test/Fake.Core.UnitTests/Fake.Core.UnitTests.fsproj
@@ -64,6 +64,7 @@
     <Compile Include="Fake.DotNet.Testing.Coverlet.fs" />
     <Compile Include="Fake.DotNet.Fsi.fs" />
     <Compile Include="Fake.DotNet.Xdt.fs" />
+    <Compile Include="Fake.DotNet.SdkAssemblyResolver.fs" />
     <Compile Include="Fake.Testing.ReportGenerator.fs" />
     <Compile Include="Fake.Testing.SonarQube.fs" />
     <Compile Include="Fake.Testing.Fixie.fs" />

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.SdkAssemblyResolver.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.SdkAssemblyResolver.fs
@@ -1,0 +1,104 @@
+module Fake.DotNet.SdkAssemblyResolver.Tests
+
+open System
+open System.IO
+open System.Runtime.InteropServices
+open System.Text
+open Fake.DotNet
+open Fake.IO
+open Expecto
+open Fake.Runtime.SdkAssemblyResolver
+open Fake.Runtime.Trace
+open Fake.SystemHelper
+
+module TestData =
+    let testFilePath file =
+        Path.Combine(__SOURCE_DIRECTORY__, "TestFiles", "Fake.DotNet.Xdt.Files", file)
+
+    let replaceNewLines text =
+        RegularExpressions.Regex.Replace(text, @"\r\n?|\n", Environment.NewLine)
+
+    let exists file =
+        File.Exists(file)
+
+    let require file =
+        if not (exists file) then
+            invalidArg "file" (sprintf "Unable to read test data from %s"
+                                       (Path.GetFullPath(file)))
+
+    let read file =
+        require file
+        File.ReadAllText(file, Encoding.UTF8)
+        |> replaceNewLines
+
+    let copy source dest =
+        require source
+        File.Copy(source, dest, true)
+
+    let delete file =
+        File.Delete(file)
+
+    let withTestDir f =
+        let tempFolder = Path.GetTempFileName()
+        File.Delete(tempFolder)
+        Directory.CreateDirectory(tempFolder)
+            |> ignore
+        try
+            f tempFolder
+        finally
+            try
+                Directory.Delete(tempFolder, true)
+            with
+            | :? DirectoryNotFoundException -> ()
+
+open Fake.IO.FileSystemOperators
+
+[<Tests>]
+let tests =
+    testList "Fake.DotNet.SdkAssemblyResolver.Tests" [
+        test "follows symlinks when dotnet is symlinked" {
+            TestData.withTestDir (fun dir ->
+                let corelib =
+                    // System.Private.CoreLib.dll
+                    System.Reflection.Assembly.GetAssembly(typeof<int>).Location
+                let dotnetContainingPath =
+                    corelib
+                    // 6.0.3 (for example)
+                    |> Path.getDirectory
+                    // Microsoft.NETCore.App
+                    |> Path.getDirectory
+                    // shared
+                    |> Path.getDirectory
+                    // dotnet
+                    |> Path.getDirectory
+
+                let exeExtension = if RuntimeInformation.IsOSPlatform OSPlatform.Windows then ".exe" else ""
+                let dotnetExeName = sprintf "dotnet%s" exeExtension
+                let dotnetExe = Path.Combine(dotnetContainingPath, dotnetExeName)
+
+                let customDotnet = dir </> dotnetExeName
+                let symlinkedDotnet = File.CreateSymbolicLink (customDotnet, dotnetExe)
+
+                Expect.isTrue symlinkedDotnet.Exists "how do symbolic links work :("
+
+                let resolverEnvVar = "FAKE_SDK_RESOLVER_CUSTOM_DOTNET_PATH"
+                let dotnetHostPathEnvVar = "DOTNET_HOST_PATH"
+                let oldDotnetHostPath = Environment.GetEnvironmentVariable dotnetHostPathEnvVar
+                let oldResolver = Environment.GetEnvironmentVariable resolverEnvVar
+
+                try
+                    Environment.SetEnvironmentVariable(dotnetHostPathEnvVar, customDotnet)
+
+                    let resolver = SdkAssemblyResolver VerboseLevel.Silent
+                    Environment.SetEnvironmentVariable(resolverEnvVar, "")
+
+                    let actual =
+                        resolver.SdkReferenceAssemblies ()
+                        |> List.head
+                    Expect.equal actual (Path.getDirectory corelib) "did not locate correct reference assemblies"
+                finally
+                    Environment.SetEnvironmentVariable(dotnetHostPathEnvVar, oldDotnetHostPath)
+                    Environment.SetEnvironmentVariable(resolverEnvVar, oldResolver)
+            )
+        }
+    ]

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.SdkAssemblyResolver.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.SdkAssemblyResolver.fs
@@ -92,10 +92,9 @@ let tests =
                     let resolver = SdkAssemblyResolver VerboseLevel.Silent
                     Environment.SetEnvironmentVariable(resolverEnvVar, "")
 
-                    let actual =
-                        resolver.SdkReferenceAssemblies ()
-                        |> List.head
-                    Expect.equal actual (Path.getDirectory corelib) "did not locate correct reference assemblies"
+                    // Observe that this does not throw
+                    resolver.SdkReferenceAssemblies ()
+                    |> ignore
                 finally
                     Environment.SetEnvironmentVariable(dotnetHostPathEnvVar, oldDotnetHostPath)
                     Environment.SetEnvironmentVariable(resolverEnvVar, oldResolver)


### PR DESCRIPTION
### Description

Resolve the path to `dotnet` fully (traversing symlinks) when trying to find the .NET reference assemblies.

This is necessary when, for example, you've installed `dotnet` using Nix. On my machine, for example:

```
➜ which dotnet
/etc/profiles/per-user/patrick/bin/dotnet
➜ readlink $(which dotnet)
/nix/store/2rhkamzmpmri3f91fcdvdgy8bbqacwyx-home-manager-path/bin/dotnet
➜ readlink $(readlink $(which dotnet))
/nix/store/q3w1pk4li282x1fml7rs8p93in5gq3ig-dotnet-sdk-6.0.100/bin/dotnet 
```
Only this final `dotnet` has a `packs` directory above it.

- [ ] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [ ] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [ ] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [ ] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [ ] (if new module) the module is in the correct namespace
- [ ] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [ ] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
