### PR TITLE
Core.Process: only set StandardEncoding if output/err is redirected

### DIFF
--- a/src/app/Fake.Core.Process/Process.fs
+++ b/src/app/Fake.Core.Process/Process.fs
@@ -415,8 +415,10 @@ module Process =
         RawProc.createProcessStarter (fun (c:RawCreateProcess) (p:Process) ->
             let si = p.StartInfo
             if Environment.isMono || AlwaysSetProcessEncoding then
-                si.StandardOutputEncoding <- ProcessEncoding
-                si.StandardErrorEncoding <- ProcessEncoding
+                if si.RedirectStandardOutput then
+                    si.StandardOutputEncoding <- ProcessEncoding
+                if si.RedirectStandardError then
+                    si.StandardErrorEncoding <- ProcessEncoding
 
             if c.TraceCommand && shouldEnableProcessTracing() then 
                 let commandLine = 


### PR DESCRIPTION
### Description

Should potentially fix https://github.com/fsprojects/FAKE/issues/2670
