### PR TITLE
GitHubCI: stop restricting build+test jobs to release/next branch

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,10 +1,7 @@
 name: FAKE Build and Test
 
 on:
-    push:
-        branches: [ release/next ]
-    pull_request:
-        branches: [ release/next ]
+    [push, pull_request]
 
 jobs:
     build:


### PR DESCRIPTION
It is better to let contributors to FAKE run their proposed changes in GitHubCI before they propose a PR. (Without this, they wouldn't know if their changes break tests until they propose a PR.)