### PR TITLE
Switch release process to manual trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,12 @@ name: FAKE Release
 # this workflow will build the project, run tests for final check, generate artifacts for a release, and release
 
 on:
-    push:
-        branches: [ master ]
+    workflow_dispatch:
+        inputs:
+            releaseVersion:
+                description: 'Release Version'
+                required: true
+                default: '1.0.0-1'
 
 jobs:
     release:
@@ -33,7 +37,7 @@ jobs:
             - name: Build fake runner
               run: dotnet pack --version-suffix 1 src/app/fake-cli/fake-cli.fsproj
             - name: add fake runner as a tool
-              run: dotnet tool install fake-cli --add-source "./src/app/fake-cli/bin/Debug" --version 1.0.0-1
+              run: dotnet tool install fake-cli --add-source "./src/app/fake-cli/bin/Debug" --version ${{ github.event.inputs.releaseVersion }}
             - name: Build
               run: dotnet fake build -t Release_BuildAndTest --parallel 3
             - name: publish build artifacts


### PR DESCRIPTION
 Providing release version as input for committing it to code after release is done.

### Description

Switch release process to manual trigger. Providing release version as input for committing it to code after release is done.

- fixes #2685

## TODO

Feel free to open the PR and ask for help

- [ ] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [ ] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [x] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [ ] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [ ] (if new module) the module is in the correct namespace
- [ ] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [x] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
