### PR TITLE
Fixes #2600

### DIFF
--- a/src/app/Fake.Core.Process/RawProc.fs
+++ b/src/app/Fake.Core.Process/RawProc.fs
@@ -33,7 +33,9 @@ module EnvMap =
         else IMap.empty
 
     let ofSeq l : EnvMap =
-        empty.AddRange(l |> Seq.map (fun (k, v) -> KeyValuePair<_,_>(k, v)))
+        empty
+            .AddRange(Environment.environVars () |> Seq.map (fun (k, v) -> KeyValuePair<_,_>(k, v)))
+            .AddRange(l |> Seq.map (fun (k, v) -> KeyValuePair<_,_>(k, v)))
 
     let create() =
         ofSeq (Environment.environVars ())


### PR DESCRIPTION
### Description

After a hint from @michaelsmithson in this [comment](https://github.com/fsprojects/FAKE/issues/2600#issuecomment-1128357314), we found the source of the issue that causes the NUnit Console runner to fail.

I commented out that call for `withEnvironment` in create process and it indeed runs the tests in the given repro repository successfully without issues.

Also, replacing `withEnvironment` with `withEnvironmentMap` runs successfully without issues. Further debugging the issue and I got a duplicate item error as shown below:

```
System.ArgumentException: An item with the same key has already been added.
at System.Runtime.CompilerServices.ConditionalWeakTable`2.Add(TKey key, TValue value)
at Microsoft.FSharp.Control.ExceptionDispatchInfoHelpers.ExceptionDispatchInfo.GetAssociatedSourceException(ExceptionDispatchInfo ) in D:\a\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 48
```

The `withEnvironment` method calls `EnvMap.ofSeq` from the Process module which has the following implementation:

```F#
let ofSeq l : EnvMap =
        empty.AddRange(l |> Seq.map (fun (k, v) -> KeyValuePair<_,_>(k, v)))
```

The `empty` is a new instance of `ImmutableDictionary`.

Comparing `withEnvironment` with `withEnvironmentMap` implemntations and the only difference is that, before adding the list of given environment variables, the `withEnvironmentMap` initializes the immutable collection with environment variables.

So, trying to add `Clear` before adding the given list of environment variables in `ofSeq` with no luck, Also, checking items in the collection before adding an item and skipping any duplicates, resulted in the same error.

What I ended up doing is initializing the empty immutable collection with environment variables before adding the given environment list. Same as `withEnvironmentMap`

Another solution would be to just replace the `withEnvironment` with `withEnvironmentMap` in NUnit create process. But this will not solve the issue from its roots.


- fixes #2600

## TODO

Feel free to open the PR and ask for help

- [ ] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [ ] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [ ] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [ ] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [ ] (if new module) the module is in the correct namespace
- [ ] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [ ] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
