### PR TITLE
Fake.Tools.Rsync: fix quiet flag typo

### DIFF
--- a/src/app/Fake.Tools.Rsync/Rsync.fs
+++ b/src/app/Fake.Tools.Rsync/Rsync.fs
@@ -274,7 +274,7 @@ module Rsync =
     let rec private actionToString =
         function
         | Verbose -> "--verbose"
-        | Quiet -> "--quit"
+        | Quiet -> "--quiet"
         | NoMotd -> "--no-motd"
         | Checksum -> "--checksum"
         | Archive -> "--archive"


### PR DESCRIPTION
### Description

Using the rsync package I noticed it threw an error when trying to use rsync with quiet. Saw that there was a typo in the flag

