### PR TITLE
On Unix like OSs, look for sqlpackage in directories specified in $PATH

### DIFF
--- a/src/app/Fake.Sql.SqlPackage/Sql.SqlPackage.fs
+++ b/src/app/Fake.Sql.SqlPackage/Sql.SqlPackage.fs
@@ -49,7 +49,7 @@ module SqlPackage =
     let internal validPaths =
         let paths = [
             if Environment.isUnix then
-                Environment.pathDirectories |> Seq.map (fun dir -> !!(dir </> "sqlpackage")) |> Seq.concat |> Seq.map (fun path -> path, 15)
+                Seq.append Environment.pathDirectories ["/usr/local/bin"; "/usr/bin"] |> Seq.map (fun dir -> !!(dir </> "sqlpackage")) |> Seq.concat |> Seq.map (fun path -> path, 15)
             else
                 let getSqlVersion (path:string) = path.Split '\\' |> Array.item 3 |> int
                 let getVsVersion (path: string) = (Path.GetDirectoryName path |> DirectoryInfo).Name |> int

--- a/src/app/Fake.Sql.SqlPackage/Sql.SqlPackage.fs
+++ b/src/app/Fake.Sql.SqlPackage/Sql.SqlPackage.fs
@@ -48,10 +48,8 @@ module SqlPackage =
 
     let internal validPaths =
         let paths = [
-            let macOrLinux = Set [ PlatformID.MacOSX; PlatformID.Unix ]
-            if macOrLinux.Contains Environment.OSVersion.Platform then
-                !!"/usr/local/bin/sqlpackage"
-                |> Seq.map (fun path -> path, 15)
+            if Environment.isUnix then
+                Environment.pathDirectories |> Seq.map (fun dir -> !!(dir </> "sqlpackage")) |> Seq.concat |> Seq.map (fun path -> path, 15)
             else
                 let getSqlVersion (path:string) = path.Split '\\' |> Array.item 3 |> int
                 let getVsVersion (path: string) = (Path.GetDirectoryName path |> DirectoryInfo).Name |> int
@@ -210,4 +208,3 @@ module SqlPackage =
                 data)
         |> Proc.run
         |> ignore
-


### PR DESCRIPTION
This PR addresses issue https://github.com/fsprojects/FAKE/issues/2701 of sqlpackage not existing in the same place on MacOS and Linux distros by following the canonical Unix practice of searching the directories specified by the `PATH` environment variable instead of using a hard-coded path.