### PR TITLE
Fix 2709.

### DIFF
--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -886,7 +886,10 @@ module MSBuild =
         fun (exePath: string) (callMsbuildExe: string -> string) ->
             let getFromCall () =
                 try
-                    let result = callMsbuildExe "/version /nologo"
+                    let result =
+                        match Environment.isUnix with
+                        | true -> callMsbuildExe "--version --nologo"
+                        | false -> callMsbuildExe "/version /nologo"
 
                     let line =
                         if result.Contains "DOTNET_CLI_TELEMETRY_OPTOUT" then


### PR DESCRIPTION
### Description

Use hyphened option style for Unix-like platforms instead of a slash for Windows.

- fixes #2709
