### PR TITLE
Add ignoreConflicts parameter to paket push

### DIFF
--- a/src/app/Fake.DotNet.Paket/Paket.fs
+++ b/src/app/Fake.DotNet.Paket/Paket.fs
@@ -132,6 +132,9 @@ module Paket =
 
             /// API key for the URL (default: value of the NUGET_KEY environment variable)
             ApiKey: string
+
+            /// Ignore any HTTP409 (Conflict) errors and treat as success (default: false)
+            IgnoreConflicts: bool
         }
 
     /// Paket push default parameters
@@ -143,7 +146,8 @@ module Paket =
           EndPoint = null
           WorkingDir = "./temp"
           DegreeOfParallelism = 8
-          ApiKey = null }
+          ApiKey = null
+          IgnoreConflicts = false }
 
     /// <summary>
     /// Paket restore packages type
@@ -206,6 +210,7 @@ module Paket =
             |> Arguments.appendNotEmpty "--url" parameters.PublishUrl
             |> Arguments.appendNotEmpty "--endpoint" parameters.EndPoint
             |> Arguments.appendNotEmpty "--api-key" parameters.ApiKey
+            |> Arguments.appendIf parameters.IgnoreConflicts "--ignoreConflicts"
             |> Arguments.append [ file ]
             |> startPaket parameters.ToolType parameters.ToolPath parameters.WorkingDir parameters.TimeOut
         | Pack parameters ->

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.Paket.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.Paket.fs
@@ -50,4 +50,20 @@ let tests =
 
               let cmd = args |> Arguments.toStartInfo
               Expect.stringContains (file.ToLower()) "paket" "Expected paket"
-              Expect.equal cmd "push testfile" "expected push command line" ]
+              Expect.equal cmd "push testfile" "expected push command line"
+          testCase "Test push --ignoreConflicts is not missing"
+          <| fun _ ->
+              let cp =
+                  Paket.createProcess (
+                      Paket.StartType.PushFile({ Paket.PaketPushDefaults() with IgnoreConflicts = true }, "testfile")
+                  )
+
+              let file, args =
+                  match cp.Command with
+                  | RawCommand (file, args) -> file, args
+                  | _ -> failwithf "expected RawCommand"
+                  |> ArgumentHelper.checkIfMono
+
+              let cmd = args |> Arguments.toStartInfo
+              Expect.stringContains (file.ToLower()) "paket" "Expected paket"
+              Expect.equal cmd "push --ignoreConflicts testfile" "expected push command line" ]


### PR DESCRIPTION
### Description

Add missing parameter `ignoreConflicts` from `paket push`

## TODO

Feel free to open the PR and ask for help

- [x] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [x] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [x] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [x] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [x] (if new module) the module is in the correct namespace
- [x] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [x] Fake [API guideline](https://fake.build/guide/contributing.html#API-Design-Guidelines) is honored
