### PR TITLE
Fix build by pinning version for Microsoft.build packages

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -2,6 +2,10 @@
 source release/dotnetcore
 source https://api.nuget.org/v3/index.json
 nuget FSharp.Core
+nuget Microsoft.Build 17.3.2
+nuget Microsoft.Build.Framework 17.3.2
+nuget Microsoft.Build.Tasks.Core 17.3.2
+nuget Microsoft.Build.Utilities.Core 17.3.2
 nuget System.AppContext prerelease
 nuget Paket.Core prerelease
 nuget Fake.Api.GitHub prerelease


### PR DESCRIPTION
### Description

Now that .NET 7 is out. It seems we need to pin `Microsoft.Build` packages in the build script to use versions for .NET 6 since the FAKE codebase uses .NET 6.
