### PR TITLE
Add GitHub API to create a pull request.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -59,6 +59,8 @@ open Fake.Core.TargetOperators
 open System.Net.Http
 open Microsoft.Deployment.DotNet.Releases
 open Fake.JavaScript
+open Octokit
+open Octokit.Internal
 
 // ****************************************************************************************************
 // ------------------------------------------- Definitions -------------------------------------------
@@ -1011,12 +1013,6 @@ Target.create "GitHubRelease" (fun _ ->
         Git.CommandHelper.directRunGitCommandAndFail gitDirectory "config user.email matthi.d@gmail.com"
         Git.CommandHelper.directRunGitCommandAndFail gitDirectory "config user.name \"Matthias Dittrich\""
 
-    // Git.Staging.stageAll gitDirectory
-    // Git.Commit.exec gitDirectory (sprintf "Bump version to %s" simpleVersion)
-    // let branch = "bump-version-to-" + simpleVersion
-    // Git.Branches.checkoutNewBranch gitDirectory "origin" branch
-    // Git.Branches.pushBranch gitDirectory "origin" branch
-
     Git.Branches.tag gitDirectory simpleVersion
     Git.Branches.pushTag gitDirectory url simpleVersion
 
@@ -1033,7 +1029,24 @@ Target.create "GitHubRelease" (fun _ ->
     |> GitHub.draftNewRelease githubReleaseUser gitName simpleVersion (release.SemVer.PreRelease <> None) release.Notes
     |> GitHub.uploadFiles files
     |> GitHub.publishDraft
-    |> Async.RunSynchronously)
+    |> Async.RunSynchronously
+    
+    let bumpVersionMessage = (sprintf "Bump version to %s" simpleVersion)
+    let branch = "bump-version-to-" + simpleVersion
+    Git.Staging.stageAll ".config"
+    Git.Commit.exec gitDirectory bumpVersionMessage
+    Git.Branches.checkoutNewBranch gitDirectory "master" branch
+    Git.Branches.pushBranch gitDirectory "origin" branch
+
+    // when we release the GitHub module, this will be replaced with GitHub.createPullRequest API
+    let pullRequest = new NewPullRequest((sprintf "Bump version to %s" simpleVersion), "bump-version-to-6.0.0-alpha004", "master")
+    let pullRequestTask (client: GitHubClient) =
+        client.PullRequest.Create("fsprojects", "FAKE", pullRequest) |> Async.AwaitTask |> Async.RunSynchronously
+        
+    GitHub.createClientWithToken token
+    |> Async.RunSynchronously
+    |> pullRequestTask
+    |> ignore)
 
 // ----------------------------------------------------------------------------------------------------
 // Artifact targets; Preparing artifacts for release from existing artifacts

--- a/build.fsx
+++ b/build.fsx
@@ -1039,9 +1039,9 @@ Target.create "GitHubRelease" (fun _ ->
     Git.Branches.pushBranch gitDirectory "origin" branch
 
     // when we release the GitHub module, this will be replaced with GitHub.createPullRequest API
-    let pullRequest = new NewPullRequest((sprintf "Bump version to %s" simpleVersion), "bump-version-to-6.0.0-alpha004", "master")
+    let pullRequest = new NewPullRequest(bumpVersionMessage, branch, "master")
     let pullRequestTask (client: GitHubClient) =
-        client.PullRequest.Create("fsprojects", "FAKE", pullRequest) |> Async.AwaitTask |> Async.RunSynchronously
+        client.PullRequest.Create(githubReleaseUser, gitName, pullRequest) |> Async.AwaitTask |> Async.RunSynchronously
         
     GitHub.createClientWithToken token
     |> Async.RunSynchronously

--- a/src/app/Fake.Api.GitHub/GitHub.fs
+++ b/src/app/Fake.Api.GitHub/GitHub.fs
@@ -445,3 +445,24 @@ module GitHub =
 
             ()
         }
+
+    /// <summary>
+    /// Create a pull request on the specified repository.
+    /// </summary>
+    ///
+    /// <param name="owner">The owner of the repository - GitHub handle</param>
+    /// <param name="repoName">The repository name</param>
+    /// <param name="pullRequest">The pull request information, including source and destination branches</param>
+    /// <param name="client">The GitHub client to use for communication</param>
+    /// <example>
+    /// <code lang="fsharp">
+    /// let pullRequest = new PullRequest("Bump FAKE runner version", "version-branch", "master")
+    ///
+    /// GitHub.createClientWithToken token
+    /// |> GitHub.createPullRequest "fsprojects" "fake" pullRequest
+    /// |> Async.RunSynchronously
+    /// </code>
+    /// </example>
+    let createPullRequest owner repoName (pullRequest: NewPullRequest) (client: Async<GitHubClient>) =
+        retryWithArg 5 client
+        <| fun client' -> async { return Async.AwaitTask <| client'.PullRequest.Create(owner, repoName, pullRequest) }


### PR DESCRIPTION
### Description

This PR adds a new API to GitHub module to create a pull request on a repository.
The API usage is as follows:
```f#
let pullRequest = new PullRequest("Bump FAKE runner version", "version-branch", "master")

GitHub.createClientWithToken token
|> GitHub.createPullRequest "fsprojects" "fake" pullRequest
|> Async.RunSynchronously
```

Also, in the FAKE's build script, this API is used to open a new branch with the FAKE runner version bumped to the newest one after a release. Before this, the build script pushes directly to the master branch. However, this is no longer possible since the master branch is now protected and needs a PR when merging changes to it.

