### PR TITLE
Return `CreateProcess<>` from CMake commands

### DIFF
--- a/src/app/Fake.Build.CMake/CMake.fs
+++ b/src/app/Fake.Build.CMake/CMake.fs
@@ -204,10 +204,8 @@ module CMake =
             CreateProcess.fromRawCommandLine cmakeExe arguments
             |> CreateProcess.withWorkingDirectory binaryDir
             |> CreateProcess.withTimeout (timeout)
-            |> Proc.run
 
-        if result.ExitCode <> 0 then
-            failwithf $"CMake failed with exit code %i{result.ExitCode}."
+        result
 
     let internal getGenerateArguments parameters =
         // CMake expects an existing source directory.


### PR DESCRIPTION
### Description

WIP

I found myself needing to add environment variables for CMake. We could add another parameter, like has been done for `timeout`, but we could just return the `CreateProcess<>` and let the developer do what they like with it.

cc @ziadadeela, contributor to Fake.Build.CMake.

I don't know:
1. if it's okay to break the contract while v6 is in alpha

Should we accept this proposal?
For:
1. allows developers control the creation of the process
2. the developer can decide how to handle errors
3. ...

Against:
1. breaks encapsulation of how CMake is run (it exposes that we're using `CreateProcess`)
2. the developer may not know what to do with a `CreateProcess<>` (they need to call `Proc.run` themselves)
3. ...

If we accept this proposal,
1. should we remove the timeout parameter and let callers add `CreateProcess.withTimeout timeout` themselves?
2. should we remove the working directory and let callers add `CreateProcess.withWorkingDirectory binaryDir` themselves?

## TODO

Feel free to open the PR and ask for help

- [ ] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [ ] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [ ] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [ ] (if new module) the module has been linked from the "side navigation" menu, edit `docs/data.json`.
- [ ] (if new module) the module is in the correct namespace.
- [ ] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [ ] Fake [API guideline](https://fake.build/guide/contributing.html#API-Design-Guidelines) is honored
