### PR TITLE
Use RollForward project property

### DIFF
--- a/src/app/fake-cli/fake-cli.fsproj
+++ b/src/app/fake-cli/fake-cli.fsproj
@@ -4,12 +4,13 @@
         <OutputType>Exe</OutputType>
         <ToolCommandName>fake</ToolCommandName>
         <TargetFramework>net6.0</TargetFramework>
+        <RollForward>Major</RollForward>
         <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
         <!-- Debian packaging -->
         <Prefix>/opt/fake</Prefix>
         <PostInstallScript>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)/debian-postinst.sh'))</PostInstallScript>
         <NoWarn>FS3186</NoWarn>
-      <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+        <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/app/fake-cli/runtimeconfig.template.json
+++ b/src/app/fake-cli/runtimeconfig.template.json
@@ -1,5 +1,0 @@
-{
-    "$schema": "https://gist.githubusercontent.com/natemcmaster/0bdee16450f8ec1823f2c11af880ceeb/raw/runtimeconfig.template.schema.json",
-    // '2' allows for major-version roll-forward
-    "rollForwardOnNoCandidateFx": 2
-}


### PR DESCRIPTION
### Description

Use project property documented here:
https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#rollforward

The rollForwardOnNoCandidateFx in runtimeconfig.template.json is the old way. Since .NET Core 3.0, it was merged into RollForward: https://github.com/dotnet/runtime/issues/43492

rollForwardOnNoCandidateFx is no longer documented on microsoft docs. Controlling behavior suggests RollForward project property: https://learn.microsoft.com/en-us/dotnet/core/versions/selection#control-roll-forward-behavior

The mapping from rollForwardOnNoCandidateFx=2 to Major is based on: https://github.com/dotnet/runtime/issues/43492
(and the design document linked in last comment there).