### PR TITLE
Fix FsDocs build and watch parameters

### DIFF
--- a/src/app/Fake.DotNet.Fsdocs/Fsdocs.fs
+++ b/src/app/Fake.DotNet.Fsdocs/Fsdocs.fs
@@ -39,10 +39,10 @@ module Fsdocs =
             Parameters: seq<string * string> option
 
             /// Disable project cracking.
-            IgnoreProjects : bool option
+            IgnoreProjects: bool option
 
             ///  In API doc generation qualify the output by the collection name, e.g. 'reference/FSharp.Core/...' instead of 'reference/...' .
-            Qualify : bool option
+            Qualify: bool option
 
             /// The tool will also generate documentation for non-public members
             NoPublic: bool option
@@ -117,6 +117,9 @@ module Fsdocs =
 
             /// Port to serve content for <c>http://localhost</c> serving.
             Port: int option
+
+            /// Build Commands
+            BuildCommandParams: BuildCommandParams option
         }
 
         /// Parameter default values.
@@ -124,7 +127,8 @@ module Fsdocs =
             { NoServer = None
               NoLaunch = None
               Open = None
-              Port = None }
+              Port = None
+              BuildCommandParams = None }
 
     let internal buildBuildCommandParams (buildParams: BuildCommandParams) =
         let buildSubstitutionParameters (subParameters: seq<string * string>) =
@@ -166,6 +170,7 @@ module Fsdocs =
         |> StringBuilder.appendIfSome watchParams.NoLaunch (fun _ -> "--nolaunch")
         |> StringBuilder.appendIfSome watchParams.Open (sprintf "--open %s")
         |> StringBuilder.appendIfSome watchParams.Port (sprintf "--port %i")
+        |> StringBuilder.appendIfSome watchParams.BuildCommandParams buildBuildCommandParams
         |> StringBuilder.toText
         |> String.trim
 

--- a/src/app/Fake.DotNet.Fsdocs/Fsdocs.fs
+++ b/src/app/Fake.DotNet.Fsdocs/Fsdocs.fs
@@ -32,11 +32,17 @@ module Fsdocs =
             /// Save images referenced in docs
             SaveImages: bool option
 
-            /// Don't add line numbers, default is to add line number.
-            NoLineNumbers: bool option
+            /// Add line numbers
+            LineNumbers: bool option
 
             /// Additional substitution parameters for templates
             Parameters: seq<string * string> option
+
+            /// Disable project cracking.
+            IgnoreProjects : bool option
+
+            ///  In API doc generation qualify the output by the collection name, e.g. 'reference/FSharp.Core/...' instead of 'reference/...' .
+            Qualify : bool option
 
             /// The tool will also generate documentation for non-public members
             NoPublic: bool option
@@ -80,8 +86,10 @@ module Fsdocs =
               NoApiDocs = None
               Eval = None
               SaveImages = None
-              NoLineNumbers = None
+              LineNumbers = None
               Parameters = None
+              IgnoreProjects = None
+              Qualify = None
               NoPublic = None
               NoDefaultContent = None
               Clean = None
@@ -135,8 +143,10 @@ module Fsdocs =
         |> StringBuilder.appendIfSome buildParams.NoApiDocs (fun _ -> "--noapidocs")
         |> StringBuilder.appendIfSome buildParams.Eval (fun _ -> "--eval")
         |> StringBuilder.appendIfSome buildParams.SaveImages (fun _ -> "--saveimages")
-        |> StringBuilder.appendIfSome buildParams.NoLineNumbers (fun _ -> "--nolinenumbers")
+        |> StringBuilder.appendIfSome buildParams.LineNumbers (fun _ -> "--linenumbers")
         |> StringBuilder.appendIfSome buildParams.Parameters (fun parameters -> buildSubstitutionParameters parameters)
+        |> StringBuilder.appendIfSome buildParams.IgnoreProjects (fun _ -> "--ignoreprojects")
+        |> StringBuilder.appendIfSome buildParams.Qualify (fun _ -> "--qualify")
         |> StringBuilder.appendIfSome buildParams.NoPublic (fun _ -> "--nonpublic")
         |> StringBuilder.appendIfSome buildParams.NoDefaultContent (fun _ -> "--nodefaultcontent")
         |> StringBuilder.appendIfSome buildParams.Clean (fun _ -> "--clean")

--- a/src/app/Fake.DotNet.Fsdocs/Fsdocs.fs
+++ b/src/app/Fake.DotNet.Fsdocs/Fsdocs.fs
@@ -130,7 +130,7 @@ module Fsdocs =
         System.Text.StringBuilder()
         |> StringBuilder.appendIfSome buildParams.Input (sprintf "--input %s")
         |> StringBuilder.appendIfSome buildParams.Projects (fun projects ->
-            sprintf "--projects %s" (projects |> String.concat ","))
+            sprintf "--projects %s" (projects |> String.concat " "))
         |> StringBuilder.appendIfSome buildParams.Output (sprintf "--output %s")
         |> StringBuilder.appendIfSome buildParams.NoApiDocs (fun _ -> "--noapidocs")
         |> StringBuilder.appendIfSome buildParams.Eval (fun _ -> "--eval")

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.Fsdocs.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.Fsdocs.fs
@@ -34,7 +34,7 @@ let tests =
               "expected to call 'build --projects src/app/Fake.Api.GitHub/Fake.Api.GitHub.fsproj,src/app/Fake.DotNet.Fsdocs/Fake.DotNet.Fsdocs.fsproj' command with projects parameter"
               |> Expect.equal
                   cmd
-                  "--projects src/app/Fake.Api.GitHub/Fake.Api.GitHub.fsproj,src/app/Fake.DotNet.Fsdocs/Fake.DotNet.Fsdocs.fsproj"
+                  "--projects src/app/Fake.Api.GitHub/Fake.Api.GitHub.fsproj src/app/Fake.DotNet.Fsdocs/Fake.DotNet.Fsdocs.fsproj"
 
           testCase "It append output parameter when its value is overriden"
           <| fun _ ->

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.Fsdocs.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.Fsdocs.fs
@@ -7,294 +7,587 @@ open Expecto
 let tests =
     testList
         "Fake.DotNet.Fsdocs.Tests"
-        [ testCase "It append input parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with Input = Some("docs-new") }
+        [ testList
+              "build"
+              [ testCase "It append input parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Input = Some("docs-new") }
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              "expected to call 'build --input docs-new' command with input parameter"
-              |> Expect.equal cmd "--input docs-new"
-
-          testCase "It append projects parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with
-                      Projects =
-                          Some(
-                              seq {
-                                  "src/app/Fake.Api.GitHub/Fake.Api.GitHub.fsproj"
-                                  "src/app/Fake.DotNet.Fsdocs/Fake.DotNet.Fsdocs.fsproj"
-                              }
-                          ) }
-
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    "expected to call 'build --input docs-new' command with input parameter"
+                    |> Expect.equal cmd "--input docs-new"
+
+                testCase "It append projects parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with
+                            Projects =
+                                Some(
+                                    seq {
+                                        "src/app/Fake.Api.GitHub/Fake.Api.GitHub.fsproj"
+                                        "src/app/Fake.DotNet.Fsdocs/Fake.DotNet.Fsdocs.fsproj"
+                                    }
+                                ) }
+
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
+
+                    "expected to call 'build --projects src/app/Fake.Api.GitHub/Fake.Api.GitHub.fsproj,src/app/Fake.DotNet.Fsdocs/Fake.DotNet.Fsdocs.fsproj' command with projects parameter"
+                    |> Expect.equal
+                        cmd
+                        "--projects src/app/Fake.Api.GitHub/Fake.Api.GitHub.fsproj src/app/Fake.DotNet.Fsdocs/Fake.DotNet.Fsdocs.fsproj"
 
-              "expected to call 'build --projects src/app/Fake.Api.GitHub/Fake.Api.GitHub.fsproj,src/app/Fake.DotNet.Fsdocs/Fake.DotNet.Fsdocs.fsproj' command with projects parameter"
-              |> Expect.equal
-                  cmd
-                  "--projects src/app/Fake.Api.GitHub/Fake.Api.GitHub.fsproj src/app/Fake.DotNet.Fsdocs/Fake.DotNet.Fsdocs.fsproj"
+                testCase "It append output parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Output = Some("site") }
 
-          testCase "It append output parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with Output = Some("site") }
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    "expected to call 'build --output site' command with output parameter"
+                    |> Expect.equal cmd "--output site"
 
-              "expected to call 'build --output site' command with output parameter"
-              |> Expect.equal cmd "--output site"
+                testCase "It append noapidocs parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with NoApiDocs = Some(true) }
 
-          testCase "It append noapidocs parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with NoApiDocs = Some(true) }
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    "expected to call 'build --noapidocs' command with noapidocs parameter"
+                    |> Expect.equal cmd "--noapidocs"
 
-              "expected to call 'build --noapidocs' command with noapidocs parameter"
-              |> Expect.equal cmd "--noapidocs"
+                testCase "It append eval parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Eval = Some(true) }
 
-          testCase "It append eval parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with Eval = Some(true) }
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    "expected to call 'build --eval' command with eval parameter"
+                    |> Expect.equal cmd "--eval"
 
-              "expected to call 'build --eval' command with eval parameter"
-              |> Expect.equal cmd "--eval"
+                testCase "It append saveimages parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with SaveImages = Some(true) }
 
-          testCase "It append saveimages parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with SaveImages = Some(true) }
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    "expected to call 'build --saveimages' command with saveimages parameter"
+                    |> Expect.equal cmd "--saveimages"
 
-              "expected to call 'build --saveimages' command with saveimages parameter"
-              |> Expect.equal cmd "--saveimages"
+                testCase "It append linenumbers parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with LineNumbers = Some(true) }
 
-          testCase "It append linenumbers parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with LineNumbers = Some(true) }
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    "expected to call 'build --linenumbers' command with linenumbers parameter"
+                    |> Expect.equal cmd "--linenumbers"
 
-              "expected to call 'build --linenumbers' command with linenumbers parameter"
-              |> Expect.equal cmd "--linenumbers"
+                testCase "It append ignoreprojects parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with IgnoreProjects = Some(true) }
 
-          testCase "It append ignoreprojects parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with IgnoreProjects = Some(true) }
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    "expected to call 'build --ignoreprojects' command with ignoreprojects parameter"
+                    |> Expect.equal cmd "--ignoreprojects"
 
-              "expected to call 'build --ignoreprojects' command with ignoreprojects parameter"
-              |> Expect.equal cmd "--ignoreprojects"
+                testCase "It append qualify parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Qualify = Some(true) }
 
-          testCase "It append qualify parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with Qualify = Some(true) }
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    "expected to call 'build --qualify' command with qualify parameter"
+                    |> Expect.equal cmd "--qualify"
 
-              "expected to call 'build --qualify' command with qualify parameter"
-              |> Expect.equal cmd "--qualify"
+                testCase "It append parameters parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with
+                            Parameters =
+                                Some(
+                                    seq {
+                                        ("root", "http://127.0.0.1:5500/")
+                                        ("fsdocs-logo-src", "http://127.0.0.1:5500/img/logo.svg")
+                                    }
+                                ) }
 
-          testCase "It append parameters parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with
-                      Parameters =
-                          Some(
-                              seq {
-                                  ("root", "http://127.0.0.1:5500/")
-                                  ("fsdocs-logo-src", "http://127.0.0.1:5500/img/logo.svg")
-                              }
-                          ) }
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    "expected to call 'build --parameters root http://127.0.0.1:5500/ fsdocs-logo-src http://127.0.0.1:5500/img/logo.svg' command with parameters parameter"
+                    |> Expect.equal
+                        cmd
+                        "--parameters root http://127.0.0.1:5500/ fsdocs-logo-src http://127.0.0.1:5500/img/logo.svg"
 
-              "expected to call 'build --parameters root http://127.0.0.1:5500/ fsdocs-logo-src http://127.0.0.1:5500/img/logo.svg' command with parameters parameter"
-              |> Expect.equal
-                  cmd
-                  "--parameters root http://127.0.0.1:5500/ fsdocs-logo-src http://127.0.0.1:5500/img/logo.svg"
+                testCase "It append nonpublic parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with NoPublic = Some(true) }
 
-          testCase "It append nonpublic parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with NoPublic = Some(true) }
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    "expected to call 'build --nonpublic' command with nonpublic parameter"
+                    |> Expect.equal cmd "--nonpublic"
 
-              "expected to call 'build --nonpublic' command with nonpublic parameter"
-              |> Expect.equal cmd "--nonpublic"
+                testCase "It append nodefaultcontent parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with NoDefaultContent = Some(true) }
 
-          testCase "It append nodefaultcontent parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with NoDefaultContent = Some(true) }
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    "expected to call 'build --nodefaultcontent' command with nodefaultcontent parameter"
+                    |> Expect.equal cmd "--nodefaultcontent"
 
-              "expected to call 'build --nodefaultcontent' command with nodefaultcontent parameter"
-              |> Expect.equal cmd "--nodefaultcontent"
+                testCase "It append clean parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Clean = Some(true) }
 
-          testCase "It append clean parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with Clean = Some(true) }
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    "expected to call 'build --clean' command with clean parameter"
+                    |> Expect.equal cmd "--clean"
+
+                testCase "It append version parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Version = Some(true) }
 
-              "expected to call 'build --clean' command with clean parameter"
-              |> Expect.equal cmd "--clean"
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-          testCase "It append version parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with Version = Some(true) }
+                    "expected to call 'build --version' command with version parameter"
+                    |> Expect.equal cmd "--version"
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                testCase "It append properties parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Properties = Some("Configuration=Release") }
 
-              "expected to call 'build --version' command with version parameter"
-              |> Expect.equal cmd "--version"
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-          testCase "It append properties parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with Properties = Some("Configuration=Release") }
+                    "expected to call 'build --properties Configuration=Release' command with properties parameter"
+                    |> Expect.equal cmd "--properties Configuration=Release"
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                testCase "It append fscoptions parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with FscOptions = Some("-r:MyAssembly.dll") }
 
-              "expected to call 'build --properties Configuration=Release' command with properties parameter"
-              |> Expect.equal cmd "--properties Configuration=Release"
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-          testCase "It append fscoptions parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with FscOptions = Some("-r:MyAssembly.dll") }
+                    "expected to call 'build --fscoptions Configuration=Release' command with fscoptions parameter"
+                    |> Expect.equal cmd "--fscoptions -r:MyAssembly.dll"
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                testCase "It append strict parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Strict = Some(true) }
 
-              "expected to call 'build --fscoptions Configuration=Release' command with fscoptions parameter"
-              |> Expect.equal cmd "--fscoptions -r:MyAssembly.dll"
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-          testCase "It append strict parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with Strict = Some(true) }
+                    "expected to call 'build --strict' command with strict parameter"
+                    |> Expect.equal cmd "--strict"
+
+                testCase "It append sourcefolder parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with SourceFolder = Some("src/app") }
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              "expected to call 'build --strict' command with strict parameter"
-              |> Expect.equal cmd "--strict"
+                    "expected to call 'build --sourcefolder src/app' command with sourcefolder parameter"
+                    |> Expect.equal cmd "--sourcefolder src/app"
 
-          testCase "It append sourcefolder parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with SourceFolder = Some("src/app") }
+                testCase "It append sourcerepo parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with SourceRepository = Some("FAKE") }
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              "expected to call 'build --sourcefolder src/app' command with sourcefolder parameter"
-              |> Expect.equal cmd "--sourcefolder src/app"
+                    "expected to call 'build --sourcerepo FAKE' command with sourcerepo parameter"
+                    |> Expect.equal cmd "--sourcerepo FAKE"
 
-          testCase "It append sourcerepo parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with SourceRepository = Some("FAKE") }
+                testCase "It append mdcomments parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with MdComments = Some(true) }
 
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              "expected to call 'build --sourcerepo FAKE' command with sourcerepo parameter"
-              |> Expect.equal cmd "--sourcerepo FAKE"
-
-          testCase "It append mdcomments parameter when its value is overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with MdComments = Some(true) }
-
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
-
-              "expected to call 'build --mdcomments' command with mdcomments parameter"
-              |> Expect.equal cmd "--mdcomments"
-
-          testCase "It append multiple parameters to build command when values are overriden"
-          <| fun _ ->
-              let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with
-                      Clean = Some(true)
-                      NoDefaultContent = Some(true)
-                      Parameters =
-                          Some(
-                              seq {
-                                  ("root", "http://127.0.0.1:5500/")
-                                  ("fsdocs-logo-src", "http://127.0.0.1:5500/img/logo.svg")
-                              }
-                          )
-                      SaveImages = Some(true)
-                      Strict = Some(true) }
-
-              let cmd = Fsdocs.buildBuildCommandParams buildParams
-
-              "expected to call 'build --saveimages --parameters root http://127.0.0.1:5500/ fsdocs-logo-src http://127.0.0.1:5500/img/logo.svg --nodefaultcontent --clean --strict' command with multiple parameters"
-              |> Expect.equal
-                  cmd
-                  "--saveimages --parameters root http://127.0.0.1:5500/ fsdocs-logo-src http://127.0.0.1:5500/img/logo.svg --nodefaultcontent --clean --strict"
-
-          testCase "It calls watch command without any parameters when using default parameters"
-          <| fun _ ->
-              let cmd = Fsdocs.buildWatchCommandParams Fsdocs.WatchCommandParams.Default
-
-              "expected to call 'watch' command without any parameters" |> Expect.equal cmd ""
-
-          testCase "It append noserver parameter when its value is overriden"
-          <| fun _ ->
-              let cmd =
-                  Fsdocs.buildWatchCommandParams { Fsdocs.WatchCommandParams.Default with NoServer = Some(true) }
-
-              "expected to call 'watch --noserver' command with noserver parameter"
-              |> Expect.equal cmd "--noserver"
-
-          testCase "It append nolaunch parameter when its value is overriden"
-          <| fun _ ->
-              let cmd =
-                  Fsdocs.buildWatchCommandParams { Fsdocs.WatchCommandParams.Default with NoLaunch = Some(true) }
-
-              "expected to call 'watch --nolaunch' command with nolaunch parameter"
-              |> Expect.equal cmd "--nolaunch"
-
-          testCase "It append open parameter when its value is overriden"
-          <| fun _ ->
-              let cmd =
-                  Fsdocs.buildWatchCommandParams
-                      { Fsdocs.WatchCommandParams.Default with Open = Some("http://localhost:/apidocs/index.html") }
-
-              "expected to call 'watch --open http://localhost:/apidocs/index.html' command with open parameter"
-              |> Expect.equal cmd "--open http://localhost:/apidocs/index.html"
-
-          testCase "It append port parameter when its value is overriden"
-          <| fun _ ->
-              let cmd =
-                  Fsdocs.buildWatchCommandParams { Fsdocs.WatchCommandParams.Default with Port = Some(3007) }
-
-              "expected to call 'watch --port 3007' command with port parameter"
-              |> Expect.equal cmd "--port 3007"
-
-          testCase "It append multiple parameters to watch command when values are overriden"
-          <| fun _ ->
-              let watchParams: Fsdocs.WatchCommandParams =
-                  { Fsdocs.WatchCommandParams.Default with
-                      Port = Some(3007)
-                      Open = Some("http://localhost:/apidocs/index.html") }
-
-              let cmd = Fsdocs.buildWatchCommandParams watchParams
-
-              "expected to call 'watch --open http://localhost:/apidocs/index.html --port 3007' command with multiple parameters"
-              |> Expect.equal cmd "--open http://localhost:/apidocs/index.html --port 3007" ]
+                    "expected to call 'build --mdcomments' command with mdcomments parameter"
+                    |> Expect.equal cmd "--mdcomments"
+
+                testCase "It append multiple parameters to build command when values are overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with
+                            Clean = Some(true)
+                            NoDefaultContent = Some(true)
+                            Parameters =
+                                Some(
+                                    seq {
+                                        ("root", "http://127.0.0.1:5500/")
+                                        ("fsdocs-logo-src", "http://127.0.0.1:5500/img/logo.svg")
+                                    }
+                                )
+                            SaveImages = Some(true)
+                            Strict = Some(true) }
+
+                    let cmd = Fsdocs.buildBuildCommandParams buildParams
+
+                    "expected to call 'build --saveimages --parameters root http://127.0.0.1:5500/ fsdocs-logo-src http://127.0.0.1:5500/img/logo.svg --nodefaultcontent --clean --strict' command with multiple parameters"
+                    |> Expect.equal
+                        cmd
+                        "--saveimages --parameters root http://127.0.0.1:5500/ fsdocs-logo-src http://127.0.0.1:5500/img/logo.svg --nodefaultcontent --clean --strict" ]
+          testList
+              "watch"
+              [
+
+                testCase "It calls watch command without any parameters when using default parameters"
+                <| fun _ ->
+                    let cmd = Fsdocs.buildWatchCommandParams Fsdocs.WatchCommandParams.Default
+
+                    "expected to call 'watch' command without any parameters" |> Expect.equal cmd ""
+
+                testCase "It append noserver parameter when its value is overriden"
+                <| fun _ ->
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams { Fsdocs.WatchCommandParams.Default with NoServer = Some(true) }
+
+                    "expected to call 'watch --noserver' command with noserver parameter"
+                    |> Expect.equal cmd "--noserver"
+
+                testCase "It append nolaunch parameter when its value is overriden"
+                <| fun _ ->
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams { Fsdocs.WatchCommandParams.Default with NoLaunch = Some(true) }
+
+                    "expected to call 'watch --nolaunch' command with nolaunch parameter"
+                    |> Expect.equal cmd "--nolaunch"
+
+                testCase "It append open parameter when its value is overriden"
+                <| fun _ ->
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with Open = Some("http://localhost:/apidocs/index.html") }
+
+                    "expected to call 'watch --open http://localhost:/apidocs/index.html' command with open parameter"
+                    |> Expect.equal cmd "--open http://localhost:/apidocs/index.html"
+
+                testCase "It append port parameter when its value is overriden"
+                <| fun _ ->
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams { Fsdocs.WatchCommandParams.Default with Port = Some(3007) }
+
+                    "expected to call 'watch --port 3007' command with port parameter"
+                    |> Expect.equal cmd "--port 3007"
+
+                testCase "It append multiple parameters to watch command when values are overriden"
+                <| fun _ ->
+                    let watchParams: Fsdocs.WatchCommandParams =
+                        { Fsdocs.WatchCommandParams.Default with
+                            Port = Some(3007)
+                            Open = Some("http://localhost:/apidocs/index.html") }
+
+                    let cmd = Fsdocs.buildWatchCommandParams watchParams
+
+                    "expected to call 'watch --open http://localhost:/apidocs/index.html --port 3007' command with multiple parameters"
+                    |> Expect.equal cmd "--open http://localhost:/apidocs/index.html --port 3007"
+
+
+                testCase "It append input parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Input = Some("docs-new") }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --input docs-new' command with input parameter"
+                    |> Expect.equal cmd "--input docs-new"
+
+                testCase "It append projects parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with
+                            Projects =
+                                Some(
+                                    seq {
+                                        "src/app/Fake.Api.GitHub/Fake.Api.GitHub.fsproj"
+                                        "src/app/Fake.DotNet.Fsdocs/Fake.DotNet.Fsdocs.fsproj"
+                                    }
+                                ) }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --projects src/app/Fake.Api.GitHub/Fake.Api.GitHub.fsproj,src/app/Fake.DotNet.Fsdocs/Fake.DotNet.Fsdocs.fsproj' command with projects parameter"
+                    |> Expect.equal
+                        cmd
+                        "--projects src/app/Fake.Api.GitHub/Fake.Api.GitHub.fsproj src/app/Fake.DotNet.Fsdocs/Fake.DotNet.Fsdocs.fsproj"
+
+                testCase "It append output parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Output = Some("site") }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --output site' command with output parameter"
+                    |> Expect.equal cmd "--output site"
+
+                testCase "It append noapidocs parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with NoApiDocs = Some(true) }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --noapidocs' command with noapidocs parameter"
+                    |> Expect.equal cmd "--noapidocs"
+
+                testCase "It append eval parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Eval = Some(true) }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --eval' command with eval parameter"
+                    |> Expect.equal cmd "--eval"
+
+                testCase "It append saveimages parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with SaveImages = Some(true) }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --saveimages' command with saveimages parameter"
+                    |> Expect.equal cmd "--saveimages"
+
+                testCase "It append linenumbers parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with LineNumbers = Some(true) }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --linenumbers' command with linenumbers parameter"
+                    |> Expect.equal cmd "--linenumbers"
+
+                testCase "It append ignoreprojects parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with IgnoreProjects = Some(true) }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --ignoreprojects' command with ignoreprojects parameter"
+                    |> Expect.equal cmd "--ignoreprojects"
+
+                testCase "It append qualify parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Qualify = Some(true) }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --qualify' command with qualify parameter"
+                    |> Expect.equal cmd "--qualify"
+
+                testCase "It append parameters parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with
+                            Parameters =
+                                Some(
+                                    seq {
+                                        ("root", "http://127.0.0.1:5500/")
+                                        ("fsdocs-logo-src", "http://127.0.0.1:5500/img/logo.svg")
+                                    }
+                                ) }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --parameters root http://127.0.0.1:5500/ fsdocs-logo-src http://127.0.0.1:5500/img/logo.svg' command with parameters parameter"
+                    |> Expect.equal
+                        cmd
+                        "--parameters root http://127.0.0.1:5500/ fsdocs-logo-src http://127.0.0.1:5500/img/logo.svg"
+
+                testCase "It append nonpublic parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with NoPublic = Some(true) }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --nonpublic' command with nonpublic parameter"
+                    |> Expect.equal cmd "--nonpublic"
+
+                testCase "It append nodefaultcontent parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with NoDefaultContent = Some(true) }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --nodefaultcontent' command with nodefaultcontent parameter"
+                    |> Expect.equal cmd "--nodefaultcontent"
+
+                testCase "It append clean parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Clean = Some(true) }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --clean' command with clean parameter"
+                    |> Expect.equal cmd "--clean"
+
+                testCase "It append version parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Version = Some(true) }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --version' command with version parameter"
+                    |> Expect.equal cmd "--version"
+
+                testCase "It append properties parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Properties = Some("Configuration=Release") }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --properties Configuration=Release' command with properties parameter"
+                    |> Expect.equal cmd "--properties Configuration=Release"
+
+                testCase "It append fscoptions parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with FscOptions = Some("-r:MyAssembly.dll") }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --fscoptions Configuration=Release' command with fscoptions parameter"
+                    |> Expect.equal cmd "--fscoptions -r:MyAssembly.dll"
+
+                testCase "It append strict parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with Strict = Some(true) }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --strict' command with strict parameter"
+                    |> Expect.equal cmd "--strict"
+
+                testCase "It append sourcefolder parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with SourceFolder = Some("src/app") }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --sourcefolder src/app' command with sourcefolder parameter"
+                    |> Expect.equal cmd "--sourcefolder src/app"
+
+                testCase "It append sourcerepo parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with SourceRepository = Some("FAKE") }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --sourcerepo FAKE' command with sourcerepo parameter"
+                    |> Expect.equal cmd "--sourcerepo FAKE"
+
+                testCase "It append mdcomments parameter when its value is overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with MdComments = Some(true) }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --mdcomments' command with mdcomments parameter"
+                    |> Expect.equal cmd "--mdcomments"
+
+                testCase "It append multiple parameters to build command when values are overriden"
+                <| fun _ ->
+                    let buildParams: Fsdocs.BuildCommandParams =
+                        { Fsdocs.BuildCommandParams.Default with
+                            Clean = Some(true)
+                            NoDefaultContent = Some(true)
+                            Parameters =
+                                Some(
+                                    seq {
+                                        ("root", "http://127.0.0.1:5500/")
+                                        ("fsdocs-logo-src", "http://127.0.0.1:5500/img/logo.svg")
+                                    }
+                                )
+                            SaveImages = Some(true)
+                            Strict = Some(true) }
+
+                    let cmd =
+                        Fsdocs.buildWatchCommandParams
+                            { Fsdocs.WatchCommandParams.Default with BuildCommandParams = Some(buildParams) }
+
+                    "expected to call 'watch --saveimages --parameters root http://127.0.0.1:5500/ fsdocs-logo-src http://127.0.0.1:5500/img/logo.svg --nodefaultcontent --clean --strict' command with multiple parameters"
+                    |> Expect.equal
+                        cmd
+                        "--saveimages --parameters root http://127.0.0.1:5500/ fsdocs-logo-src http://127.0.0.1:5500/img/logo.svg --nodefaultcontent --clean --strict" ]
+
+
+
+          ]

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.Fsdocs.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.Fsdocs.fs
@@ -76,15 +76,35 @@ let tests =
               "expected to call 'build --saveimages' command with saveimages parameter"
               |> Expect.equal cmd "--saveimages"
 
-          testCase "It append nolinenumbers parameter when its value is overriden"
+          testCase "It append linenumbers parameter when its value is overriden"
           <| fun _ ->
               let buildParams: Fsdocs.BuildCommandParams =
-                  { Fsdocs.BuildCommandParams.Default with NoLineNumbers = Some(true) }
+                  { Fsdocs.BuildCommandParams.Default with LineNumbers = Some(true) }
 
               let cmd = Fsdocs.buildBuildCommandParams buildParams
 
-              "expected to call 'build --nolinenumbers' command with nolinenumbers parameter"
-              |> Expect.equal cmd "--nolinenumbers"
+              "expected to call 'build --linenumbers' command with linenumbers parameter"
+              |> Expect.equal cmd "--linenumbers"
+
+          testCase "It append ignoreprojects parameter when its value is overriden"
+          <| fun _ ->
+              let buildParams: Fsdocs.BuildCommandParams =
+                  { Fsdocs.BuildCommandParams.Default with IgnoreProjects = Some(true) }
+
+              let cmd = Fsdocs.buildBuildCommandParams buildParams
+
+              "expected to call 'build --ignoreprojects' command with ignoreprojects parameter"
+              |> Expect.equal cmd "--ignoreprojects"
+
+          testCase "It append qualify parameter when its value is overriden"
+          <| fun _ ->
+              let buildParams: Fsdocs.BuildCommandParams =
+                  { Fsdocs.BuildCommandParams.Default with Qualify = Some(true) }
+
+              let cmd = Fsdocs.buildBuildCommandParams buildParams
+
+              "expected to call 'build --qualify' command with qualify parameter"
+              |> Expect.equal cmd "--qualify"
 
           testCase "It append parameters parameter when its value is overriden"
           <| fun _ ->


### PR DESCRIPTION
### Description

- Updates Builds Parameters to align with what's available in FsDocs tool
- Fixes an issue with `--projects` not concatenating correctly
- Updates Watch Parameters to align with what's available in FsDocs tool

If available, link to an existing issue this PR fixes. For example:

- fixes #2736 

## TODO

- [x] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [x] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [x] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [ ] (if new module) the module has been linked from the "side navigation" menu, edit `docs/data.json`.
- [ ] (if new module) the module is in the correct namespace.
- [ ] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [x] Fake [API guideline](https://fake.build/guide/contributing.html#API-Design-Guidelines) is honored
