### PR TITLE
[MSBuild] Fixed trailing garbage

### DIFF
--- a/src/app/Fake.BuildServer.AppVeyor/AppVeyorInternal.fs
+++ b/src/app/Fake.BuildServer.AppVeyor/AppVeyorInternal.fs
@@ -5,7 +5,6 @@ open System.Text
 open Fake.Core
 open Fake.IO
 open Fake.Net
-open Fake.Core
 
 /// [omit]
 module internal AppVeyorInternal =
@@ -54,18 +53,8 @@ module internal AppVeyorInternal =
                 // because otherwise there might be recursive failure...
                 eprintfn "AppVeyor 'AddMessage' failed: %O" e
 
-    /// Adds quotes around the string
-    /// [omit]
-    let private quote (str: string) = "\"" + str.Replace("\"", "\\\"") + "\""
-
-    /// Adds quotes around the string if needed
-    /// [omit]
-    let private quoteIfNeeded str =
-        if String.isNullOrEmpty str then ""
-        elif str.Contains " " then quote str
-        else str
-
-    let private quoteString str = quoteIfNeeded str
+    /// quote and escape the single argument, if required.
+    let private quoteString str = Args.toWindowsCommandLine [str]
 
     /// Starts the test case.
     let StartTestCase testSuiteName testCaseName =

--- a/src/app/Fake.BuildServer.AppVeyor/AppVeyorInternal.fs
+++ b/src/app/Fake.BuildServer.AppVeyor/AppVeyorInternal.fs
@@ -56,7 +56,7 @@ module internal AppVeyorInternal =
 
     /// Adds quotes around the string
     /// [omit]
-    let private quote (str:string) = "\"" + str.Replace("\"","\\\"") + "\""
+    let private quote (str: string) = "\"" + str.Replace("\"", "\\\"") + "\""
 
     /// Adds quotes around the string if needed
     /// [omit]

--- a/src/app/Fake.BuildServer.AppVeyor/AppVeyorInternal.fs
+++ b/src/app/Fake.BuildServer.AppVeyor/AppVeyorInternal.fs
@@ -53,10 +53,7 @@ module internal AppVeyorInternal =
                 // because otherwise there might be recursive failure...
                 eprintfn "AppVeyor 'AddMessage' failed: %O" e
 
-    let internal quoteString str =
-        StringBuilder()
-        |> StringBuilder.appendQuotedIfNotNull Some str
-        |> StringBuilder.toText
+    let internal quoteString str = sprintf "\"%s\"" str
 
     /// Starts the test case.
     let StartTestCase testSuiteName testCaseName =

--- a/src/app/Fake.BuildServer.AppVeyor/AppVeyorInternal.fs
+++ b/src/app/Fake.BuildServer.AppVeyor/AppVeyorInternal.fs
@@ -5,6 +5,7 @@ open System.Text
 open Fake.Core
 open Fake.IO
 open Fake.Net
+open Fake.Core
 
 /// [omit]
 module internal AppVeyorInternal =
@@ -53,7 +54,18 @@ module internal AppVeyorInternal =
                 // because otherwise there might be recursive failure...
                 eprintfn "AppVeyor 'AddMessage' failed: %O" e
 
-    let internal quoteString str = sprintf "\"%s\"" str
+    /// Adds quotes around the string
+    /// [omit]
+    let private quote (str:string) = "\"" + str.Replace("\"","\\\"") + "\""
+
+    /// Adds quotes around the string if needed
+    /// [omit]
+    let private quoteIfNeeded str =
+        if String.isNullOrEmpty str then ""
+        elif str.Contains " " then quote str
+        else str
+
+    let private quoteString str = quoteIfNeeded str
 
     /// Starts the test case.
     let StartTestCase testSuiteName testCaseName =

--- a/src/app/Fake.BuildServer.AppVeyor/AppVeyorInternal.fs
+++ b/src/app/Fake.BuildServer.AppVeyor/AppVeyorInternal.fs
@@ -54,7 +54,7 @@ module internal AppVeyorInternal =
                 eprintfn "AppVeyor 'AddMessage' failed: %O" e
 
     /// quote and escape the single argument, if required.
-    let private quoteString str = Args.toWindowsCommandLine [str]
+    let private quoteString str = Args.toWindowsCommandLine [ str ]
 
     /// Starts the test case.
     let StartTestCase testSuiteName testCaseName =

--- a/src/app/Fake.Core.Process/CmdLineParsing.fs
+++ b/src/app/Fake.Core.Process/CmdLineParsing.fs
@@ -140,7 +140,7 @@ type FilePath = string
 module Args =
     /// <summary>
     /// Convert the given argument list to a conforming windows command line string, escapes parameter in quotes if
-    /// needed (currently always but this might change).
+    /// needed.
     /// </summary>
     ///
     /// <param name="args">The arguments list</param>

--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -772,7 +772,10 @@ module DotNet =
         let options = setOptions buildOptions
 
         let cmdArgs =
-            buildCommand (command |> Args.fromWindowsCommandLine |> Seq.toList) (Args.fromWindowsCommandLine args |> Seq.toList) options
+            buildCommand
+                (command |> Args.fromWindowsCommandLine |> Seq.toList)
+                (Args.fromWindowsCommandLine args |> Seq.toList)
+                options
 
         run cmdArgs options
 

--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -772,10 +772,7 @@ module DotNet =
         let options = setOptions buildOptions
 
         let cmdArgs =
-            buildCommand
-                (command |> Args.fromWindowsCommandLine |> Seq.toList)
-                args
-                options
+            buildCommand (command |> Args.fromWindowsCommandLine |> Seq.toList) args options
 
         run cmdArgs options
 
@@ -945,7 +942,7 @@ module DotNet =
     let getVersion setParams =
         use __ = Trace.traceTask "DotNet:version" "running dotnet --version"
         let param = VersionOptions.Create() |> setParams
-        let args = ["--version"]
+        let args = [ "--version" ]
         let result = exec (fun _ -> param.Common) "" args
 
         if not result.OK then

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -685,7 +685,7 @@ module MSBuild =
                     value
 
             a, fileName |> Path.getFullName)
-            
+
     let internal quoteString str = sprintf "\"%s\"" str
 
     let rec private getProjectReferences (projectFileName: string) =

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -1031,7 +1031,7 @@ module MSBuild =
             else
                 sprintf "%s>" msBuildParams.WorkingDirectory
 
-        Trace.tracefn "%s%s %A" wd msBuildParams.ToolPath args
+        Trace.tracefn "%s%s %s" wd msBuildParams.ToolPath (Args.toWindowsCommandLine args)
 
         let results = System.Collections.Generic.List<ConsoleMessage>()
 
@@ -1100,7 +1100,7 @@ module MSBuild =
             else
                 sprintf "%s>" msBuildParams.WorkingDirectory
 
-        Trace.tracefn "%s%s %A" wd msBuildParams.ToolPath args
+        Trace.tracefn "%s%s %s" wd msBuildParams.ToolPath (Args.toWindowsCommandLine args)
 
         let processResult =
             CreateProcess.fromRawCommand msBuildParams.ToolPath args

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -890,8 +890,8 @@ module MSBuild =
                 try
                     let result =
                         match Environment.isUnix with
-                        | true -> callMsbuildExe ["--version"; "--nologo"]
-                        | false -> callMsbuildExe ["/version"; "/nologo"]
+                        | true -> callMsbuildExe [ "--version"; "--nologo" ]
+                        | false -> callMsbuildExe [ "/version"; "/nologo" ]
 
                     let line =
                         if result.Contains "DOTNET_CLI_TELEMETRY_OPTOUT" then
@@ -938,8 +938,7 @@ module MSBuild =
                     else
                         Path.Combine(libFolder, "net46", "StructuredLogger.dll")
 
-                Some path,
-                (argList @ [ sprintf "/logger:BinaryLogger,%s;%s" assemblyPath path ])
+                Some path, (argList @ [ sprintf "/logger:BinaryLogger,%s;%s" assemblyPath path ])
             else
                 Trace.traceFAKE
                     "msbuild version '%O' doesn't support binary logger, please set the msbuild argument 'DisableInternalBinLog' to 'true' to disable this warning."

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -873,9 +873,14 @@ module MSBuild =
         |> Seq.choose id
         |> Seq.map (fun (k, v) -> "/" + k + (if String.isNullOrEmpty v then "" else ":" + v))
         |> Seq.toList
-
+        
     /// [omit]
     let buildArgs (setParams: MSBuildParams -> MSBuildParams) =
+        let p = MSBuildParams.Create() |> setParams
+        p, fromCliArguments p.CliArguments |> Args.toWindowsCommandLine
+
+    /// [omit]
+    let buildArgs2 (setParams: MSBuildParams -> MSBuildParams) =
         let p = MSBuildParams.Create() |> setParams
         p, fromCliArguments p.CliArguments
 
@@ -1011,7 +1016,7 @@ module MSBuild =
     /// <param name="setParams">A function that overwrites the default MSBuildParams</param>
     /// <param name="project">A string with the path to the project file to build.</param>
     let buildWithRedirect setParams project =
-        let msBuildParams, argsString = buildArgs setParams
+        let msBuildParams, argsString = buildArgs2 setParams
 
         let args = project :: argsString
 
@@ -1080,7 +1085,7 @@ module MSBuild =
     /// </example>
     let build setParams project =
         use __ = Trace.traceTask "MSBuild" project
-        let msBuildParams, argsString = buildArgs setParams
+        let msBuildParams, argsString = buildArgs2 setParams
 
         let args = project :: argsString
 

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -685,11 +685,8 @@ module MSBuild =
                     value
 
             a, fileName |> Path.getFullName)
-
-    let internal quoteString str =
-        StringBuilder()
-        |> StringBuilder.appendQuotedIfNotNull Some str
-        |> StringBuilder.toText
+            
+    let internal quoteString str = sprintf "\"%s\"" str
 
     let rec private getProjectReferences (projectFileName: string) =
         match projectFileName.EndsWith ".sln" with

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -874,7 +874,7 @@ module MSBuild =
           yield! properties ]
         |> Seq.choose id
         |> Seq.map (fun (k, v) -> "/" + k + (if String.isNullOrEmpty v then "" else ":" + v))
-        |> Args.toWindowsCommandLine
+        |> Seq.toArray
 
     /// [omit]
     let buildArgs (setParams: MSBuildParams -> MSBuildParams) =
@@ -885,13 +885,13 @@ module MSBuild =
     let internal getVersion =
         let cache = System.Collections.Concurrent.ConcurrentDictionary<string, Version>()
 
-        fun (exePath: string) (callMsbuildExe: string -> string) ->
+        fun (exePath: string) (callMsbuildExe: string array -> string) ->
             let getFromCall () =
                 try
                     let result =
                         match Environment.isUnix with
-                        | true -> callMsbuildExe "--version --nologo"
-                        | false -> callMsbuildExe "/version /nologo"
+                        | true -> callMsbuildExe [|"--version"; "--nologo"|]
+                        | false -> callMsbuildExe [|"/version"; "/nologo"|]
 
                     let line =
                         if result.Contains "DOTNET_CLI_TELEMETRY_OPTOUT" then
@@ -911,15 +911,15 @@ module MSBuild =
 
     let internal addBinaryLogger
         (exePath: string)
-        (callMsbuildExe: string -> string)
-        (args: string)
+        (callMsbuildExe: string array -> string)
+        (args: string array)
         (disableFakeBinLogger: bool)
         =
 #if !NO_MSBUILD_BINLOG
         if disableFakeBinLogger then
             None, args
         else
-            let argList = Args.fromWindowsCommandLine args |> Seq.toList
+            let argList = args |> Seq.toList
             let path = Path.GetTempFileName()
             File.Delete(path)
             let path = path + ".binlog"
@@ -927,7 +927,7 @@ module MSBuild =
             let v = getVersion exePath callMsbuildExe
 
             if v >= versionToUseBinLog then
-                Some path, Args.toWindowsCommandLine (argList @ [ "/bl:" + path ])
+                Some path, Seq.toArray (argList @ [ "/bl:" + path ])
             elif v >= versionToUseStructuredLogger then
                 let assemblyPath =
                     let currentPath = MSBuildBinLog.structuredLogAssemblyPath
@@ -939,7 +939,7 @@ module MSBuild =
                         Path.Combine(libFolder, "net46", "StructuredLogger.dll")
 
                 Some path,
-                Args.toWindowsCommandLine (argList @ [ sprintf "/logger:BinaryLogger,%s;%s" assemblyPath path ])
+                Seq.toArray (argList @ [ sprintf "/logger:BinaryLogger,%s;%s" assemblyPath path ])
             else
                 Trace.traceFAKE
                     "msbuild version '%O' doesn't support binary logger, please set the msbuild argument 'DisableInternalBinLog' to 'true' to disable this warning."
@@ -995,7 +995,7 @@ module MSBuild =
         let messageF msg = results.Add msg
 
         let processResult =
-            CreateProcess.fromRawCommandLine msBuildParams.ToolPath args
+            CreateProcess.fromRawCommand msBuildParams.ToolPath args
             |> CreateProcess.withTimeout TimeSpan.MaxValue
             |> CreateProcess.withEnvironment (msBuildParams.Environment |> Map.toList)
             |> CreateProcess.redirectOutput
@@ -1016,7 +1016,7 @@ module MSBuild =
     let buildWithRedirect setParams project =
         let msBuildParams, argsString = buildArgs setParams
 
-        let args = quoteString (project + " " + argsString)
+        let args = [| yield project; yield! argsString |]
 
         let binlogPath, args =
             addBinaryLogger
@@ -1031,7 +1031,7 @@ module MSBuild =
             else
                 sprintf "%s>" msBuildParams.WorkingDirectory
 
-        Trace.tracefn "%s%s %s" wd msBuildParams.ToolPath args
+        Trace.tracefn "%s%s %A" wd msBuildParams.ToolPath args
 
         let results = System.Collections.Generic.List<ConsoleMessage>()
 
@@ -1042,7 +1042,7 @@ module MSBuild =
             results.Add(ConsoleMessage.CreateOut msg)
 
         let processResult =
-            CreateProcess.fromRawCommandLine msBuildParams.ToolPath args
+            CreateProcess.fromRawCommand msBuildParams.ToolPath args
             |> CreateProcess.withTimeout TimeSpan.MaxValue
             |> CreateProcess.withEnvironment (msBuildParams.Environment |> Map.toList)
             |> CreateProcess.withWorkingDirectory msBuildParams.WorkingDirectory
@@ -1085,7 +1085,7 @@ module MSBuild =
         use __ = Trace.traceTask "MSBuild" project
         let msBuildParams, argsString = buildArgs setParams
 
-        let args = quoteString (project + " " + argsString)
+        let args = [| yield project; yield! argsString |]
 
         let binlogPath, args =
             addBinaryLogger
@@ -1100,10 +1100,10 @@ module MSBuild =
             else
                 sprintf "%s>" msBuildParams.WorkingDirectory
 
-        Trace.tracefn "%s%s %s" wd msBuildParams.ToolPath args
+        Trace.tracefn "%s%s %A" wd msBuildParams.ToolPath args
 
         let processResult =
-            CreateProcess.fromRawCommandLine msBuildParams.ToolPath args
+            CreateProcess.fromRawCommand msBuildParams.ToolPath args
             |> CreateProcess.withWorkingDirectory msBuildParams.WorkingDirectory
             |> CreateProcess.withTimeout TimeSpan.MaxValue
             |> CreateProcess.withEnvironment (msBuildParams.Environment |> Map.toList)

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -686,8 +686,6 @@ module MSBuild =
 
             a, fileName |> Path.getFullName)
 
-    let internal quoteString str = sprintf "\"%s\"" str
-
     let rec private getProjectReferences (projectFileName: string) =
         match projectFileName.EndsWith ".sln" with
         | true -> Set.empty

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -873,7 +873,7 @@ module MSBuild =
         |> Seq.choose id
         |> Seq.map (fun (k, v) -> "/" + k + (if String.isNullOrEmpty v then "" else ":" + v))
         |> Seq.toList
-        
+
     /// [omit]
     let buildArgs (setParams: MSBuildParams -> MSBuildParams) =
         let p = MSBuildParams.Create() |> setParams

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -875,12 +875,14 @@ module MSBuild =
         |> Seq.toList
 
     /// [omit]
-    let buildArgs (setParams: MSBuildParams -> MSBuildParams) =
+    let buildArgs (setParams: MSBuildParams -> MSBuildParams) : MSBuildParams * string =
         let p = MSBuildParams.Create() |> setParams
         p, fromCliArguments p.CliArguments |> Args.toWindowsCommandLine
 
-    /// [omit]
-    let buildArgs2 (setParams: MSBuildParams -> MSBuildParams) =
+    /// <summary>
+    ///   similar to 'buildArgs' but returns a string list instead of a single string for the arguments
+    /// </summary>
+    let private buildArgsToList (setParams: MSBuildParams -> MSBuildParams) : MSBuildParams * string list =
         let p = MSBuildParams.Create() |> setParams
         p, fromCliArguments p.CliArguments
 
@@ -1016,9 +1018,9 @@ module MSBuild =
     /// <param name="setParams">A function that overwrites the default MSBuildParams</param>
     /// <param name="project">A string with the path to the project file to build.</param>
     let buildWithRedirect setParams project =
-        let msBuildParams, argsString = buildArgs2 setParams
+        let msBuildParams, argsList = buildArgsToList setParams
 
-        let args = project :: argsString
+        let args = project :: argsList
 
         let binlogPath, args =
             addBinaryLogger
@@ -1085,9 +1087,9 @@ module MSBuild =
     /// </example>
     let build setParams project =
         use __ = Trace.traceTask "MSBuild" project
-        let msBuildParams, argsString = buildArgs2 setParams
+        let msBuildParams, argsList = buildArgsToList setParams
 
-        let args = project :: argsString
+        let args = project :: argsList
 
         let binlogPath, args =
             addBinaryLogger


### PR DESCRIPTION
fixes https://github.com/fsprojects/FAKE/issues/2738

---------

The previous use of ``appendQuotedIfNotNull`` doesn't make any sense, it passes ``Some`` as a function as the first parameter, which then get's formatted through ``%A`` into a string like ``<fun:quoteString@686>``. The intention was probably ``(Some str)``, but this again doesn't work.

![image](https://user-images.githubusercontent.com/4236651/224298458-9c9147cb-ecec-4855-97ff-68a76742f78c.png)


Just wrapping it in quotes is probably not strictly correct, we would also need to escape existing quotes inside the string, but it quickly fixes the code without a regression.