### PR TITLE
test: fix typo in getting-started.md

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -99,7 +99,7 @@ the dependency we specified (FAKE's target module). Paket has a
 After configuring Paket, you are ready to run your script. Enter the following command to do so:
 
 ```shell
-dotnet si build.fsx --compilertool:"~/.nuget/packages/fsharp.dependencymanager.paket/6.0.0-alpha055/lib/netstandard2.0"
+dotnet fsi build.fsx --compilertool:"~/.nuget/packages/fsharp.dependencymanager.paket/6.0.0-alpha055/lib/netstandard2.0"
 ```
 
 


### PR DESCRIPTION
### Description

Just fixed a small typo in the documentation. There is no `dotnet si` command. Just checked it if I did not knew that command:
```
Could not execute because the specified command or file was not found.
Possible reasons for this include:
  * You misspelled a built-in dotnet command.
  * You intended to execute a .NET program, but dotnet-si does not exist.
  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.
```