### PR TITLE
allow newer .NET SDKs with rollForward latestMinor

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
     "sdk" : {
-        "version": "6.0.101"
+        "version": "6.0.101",
+        "rollForward": "latestMinor"
     }
 }


### PR DESCRIPTION
I have `6.0.408` installed, but the `global.json` limits the SDK to `6.0.101`. This allows a newer `6.0.x` to work. Avoids this error:
```
PS C:\Users\cataggar\ms\FAKE> dotnet restore
The command could not be loaded, possibly because:
  * You intended to execute a .NET application:
      The application 'restore' does not exist.
  * You intended to execute a .NET SDK command:
      A compatible .NET SDK was not found.

Requested SDK version: 6.0.101
global.json file: C:\Users\cataggar\ms\FAKE\global.json

Installed SDKs:
6.0.201 [C:\Program Files\dotnet\sdk]
6.0.408 [C:\Program Files\dotnet\sdk]
7.0.302 [C:\Program Files\dotnet\sdk]

Install the [6.0.101] .NET SDK or update [C:\Users\cataggar\ms\FAKE\global.json] to match an installed SDK.
```