### PR TITLE
add Context.setExecutionContextFromCommandLineArgs

### DIFF
--- a/src/app/Fake.Core.Context/Context.fs
+++ b/src/app/Fake.Core.Context/Context.fs
@@ -193,3 +193,14 @@ module Context =
             invalidOp
                 "no Fake Execution context was found. You can initialize one via Fake.Core.Context.setExecutionContext"
         | RuntimeContext.Fake e -> e
+
+    /// <summary>
+    /// Creates and sets the FAKE execution context from command line arguments.
+    /// </summary>
+    let setExecutionContextFromCommandLineArgs scriptFile: unit =
+        System.Environment.GetCommandLineArgs()
+        |> Array.skip 2 // skip fsi & scriptFile
+        |> Array.toList
+        |> FakeExecutionContext.Create false scriptFile
+        |> RuntimeContext.Fake
+        |> setExecutionContext


### PR DESCRIPTION

This moves this [boilerplate](https://github.com/fsprojects/FAKE/issues/2719#issuecomment-1470687052) into a function. A minimal build script that works on .NET 6 & .NET 7 with Visual Studio IntelliSense and works with private NuGet feeds will now be:

``` fsi
#!/usr/bin/env -S dotnet fsi
#r "nuget: Fake.Core.Target"

Fake.Core.Context.setExecutionContextFromCommandLineArgs __SOURCE_FILE__

open Fake.Core

Target.create "clean" (fun _ ->
  Trace.log "Cleaning stuff"
)

Target.create "build" (fun _ ->
  Trace.log "Building the app"
)

Target.create "deploy" (fun _ ->
  Trace.log "Deploying app"
)

open Fake.Core.TargetOperators

"clean"
  ==> "build"
  ==> "deploy"

Target.runOrList()
```

This can be run with `dotnet fsi build.fsx`. On Linux or Mac OSX, this can be run with `./buid.fsx` as well.