### PR TITLE
Fixed `NullReferenceException` on missing `version` in `global.json`

### DIFF
--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -66,8 +66,12 @@ module DotNet =
                 let content = File.ReadAllText globalJson.FullName
                 let json = JObject.Parse content
                 let sdk = json.Item("sdk") :?> JObject
-                let version = sdk.Property("version").Value.ToString()
-                Some version
+                match sdk.Property("version") with
+                | null -> None
+                | version ->
+                    let versionValue = version.Value.ToString()
+                    let _ = Version.Parse (versionValue)
+                    Some versionValue
             with exn ->
                 failwithf "Could not parse `sdk.version` from global.json at '%s': %s" globalJson.FullName exn.Message
 


### PR DESCRIPTION
- fixes #2756

- [ ] unit or integration test exists (Is it needed? Where to write it?)
  
- [X] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [X] Fake [API guideline](https://fake.build/guide/contributing.html#API-Design-Guidelines) is honored
