### PR TITLE
Update Github actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,9 +11,9 @@ jobs:
             matrix:
                 os: [ubuntu-latest, windows-latest, macOS-latest]
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - name: Setup .NET 6
-              uses: actions/setup-dotnet@v1
+              uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: '6.0.101'
             - name: Restore dotnet tools
@@ -27,7 +27,7 @@ jobs:
             - name: Build
               run: dotnet fake build --parallel 3
             - name: publish build artifacts
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               with:
                   name: fake-artifacts
                   path: release/artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
         runs-on: windows-latest
         environment: Production
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - name: Setup .NET 6
-              uses: actions/setup-dotnet@v1
+              uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: '6.0.101'
             - name: Restore dotnet tools
@@ -31,7 +31,7 @@ jobs:
             - name: Build
               run: dotnet fake build -t Release_BuildAndTest --parallel 3
             - name: publish build artifacts
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               with:
                   name: fake-artifacts
                   path: release/artifacts


### PR DESCRIPTION
### Description

When looking at some build results I noticed a number of warnings about old versions of github actions using deprecated versions of node:
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-dotnet@v1, actions/upload-artifact@v2
```
so I thought i'd have a go at updating them.