### PR TITLE
add support for /tl:[auto|on|off] msbuild flag

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,8 +3,7 @@
 ## 6.0.1 - 2024-07-11
 * BUGFIX: MSBuild.build adds a bad string at the end of properties, thanks @0x53A - https://github.com/fsprojects/FAKE/issues/2738
 * ENHANCEMENT: Added shorthash to git functions, thanks @voronoipotato - https://github.com/fsprojects/FAKE/pull/2752
-* ENHANCEMENT: Fixes for usage in .NET 8.0 enviroment projects.
-* ENHANCEMENT: Support for /tl:[auto:on:off] msbuild flag, thanks @smoothdeveloper - 
+* ENHANCEMENT: Support for `/tl:[auto:on:off]` msbuild flag, thanks @smoothdeveloper - https://github.com/fsprojects/FAKE/pull/2768* ENHANCEMENT: Fixes for usage in .NET 8.0 enviroment projects.
 
 ## 6.0.0 - 2023-02-20
 * ENHANCEMENT: Site UI fixes and documentation link fixes.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 * BUGFIX: MSBuild.build adds a bad string at the end of properties, thanks @0x53A - https://github.com/fsprojects/FAKE/issues/2738
 * ENHANCEMENT: Added shorthash to git functions, thanks @voronoipotato - https://github.com/fsprojects/FAKE/pull/2752
 * ENHANCEMENT: Fixes for usage in .NET 8.0 enviroment projects.
+* ENHANCEMENT: Support for /tl:[auto:on:off] msbuild flag, thanks @smoothdeveloper - 
 
 ## 6.0.0 - 2023-02-20
 * ENHANCEMENT: Site UI fixes and documentation link fixes.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,8 @@
 ## 6.0.1 - 2024-07-11
 * BUGFIX: MSBuild.build adds a bad string at the end of properties, thanks @0x53A - https://github.com/fsprojects/FAKE/issues/2738
 * ENHANCEMENT: Added shorthash to git functions, thanks @voronoipotato - https://github.com/fsprojects/FAKE/pull/2752
-* ENHANCEMENT: Support for `/tl:[auto:on:off]` msbuild flag, thanks @smoothdeveloper - https://github.com/fsprojects/FAKE/pull/2768* ENHANCEMENT: Fixes for usage in .NET 8.0 enviroment projects.
+* ENHANCEMENT: Support for `/tl:[auto:on:off]` msbuild flag, thanks @smoothdeveloper - https://github.com/fsprojects/FAKE/pull/2768
+* ENHANCEMENT: Fixes for usage in .NET 8.0 enviroment projects.
 
 ## 6.0.0 - 2023-02-20
 * ENHANCEMENT: Site UI fixes and documentation link fixes.

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -37,12 +37,13 @@ type MSBuildVerbosity =
 /// Specifies whether the terminal logger should be used for the build output. The default is auto, which first verifies the environment before enabling terminal logging. The environment check verifies that the terminal is capable of using modern output features and isn't using a redirected standard output before enabling the new logger. on skips the environment check and enables terminal logging. off skips the environment check and uses the default console logger.
 ///
 /// The terminal logger shows you the restore phase followed by the build phase. During each phase, the currently building projects appear at the bottom of the terminal. Each project that's building outputs both the MSBuild target currently being built and the amount of time spent on that target. You can search this information to learn more about the build. When a project is finished building, a single "build completed" section is written that captures:
-///
-/// * The name of the built project.
-/// * The target framework (if multi-targeted).
-/// * The status of that build.
-/// * The primary output of that build (which is hyperlinked).
-/// * Any diagnostics generated for that project.
+/// <ul>
+/// <li>The name of the built project.</li>
+/// <li>The target framework (if multi-targeted).</li>
+/// <li>The status of that build.</li>
+/// <li>The primary output of that build (which is hyperlinked).</li>
+/// <li>Any diagnostics generated for that project.</li>
+/// </ul>
 /// This option is available starting in .NET 8.
 /// </summary>
 [<RequireQualifiedAccess>]

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -34,9 +34,9 @@ type MSBuildVerbosity =
     | Diagnostic
 
 /// <summary>
-/// Specifies whether the terminal logger should be used for the build output. The default is auto, which first verifies the environment before enabling terminal logging. The environment check verifies that the terminal is capable of using modern output features and isn't using a redirected standard output before enabling the new logger. on skips the environment check and enables terminal logging. off skips the environment check and uses the default console logger.
-///
-/// The terminal logger shows you the restore phase followed by the build phase. During each phase, the currently building projects appear at the bottom of the terminal. Each project that's building outputs both the MSBuild target currently being built and the amount of time spent on that target. You can search this information to learn more about the build. When a project is finished building, a single "build completed" section is written that captures:
+/// <para>Specifies whether the terminal logger should be used for the build output. The default is auto, which first verifies the environment before enabling terminal logging. The environment check verifies that the terminal is capable of using modern output features and isn't using a redirected standard output before enabling the new logger. on skips the environment check and enables terminal logging. off skips the environment check and uses the default console logger.</para>
+/// <para>The terminal logger shows you the restore phase followed by the build phase. During each phase, the currently building projects appear at the bottom of the terminal. Each project that's building outputs both the MSBuild target currently being built and the amount of time spent on that target. You can search this information to learn more about the build. When a project is finished building, a single "build completed" section is written that captures:</para>
+/// <para>
 /// <ul>
 /// <li>The name of the built project.</li>
 /// <li>The target framework (if multi-targeted).</li>
@@ -44,6 +44,7 @@ type MSBuildVerbosity =
 /// <li>The primary output of that build (which is hyperlinked).</li>
 /// <li>Any diagnostics generated for that project.</li>
 /// </ul>
+/// </para>
 /// </summary>
 /// <remarks>This option is available starting in .NET 8.</remarks>
 [<RequireQualifiedAccess>]

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -44,8 +44,8 @@ type MSBuildVerbosity =
 /// <li>The primary output of that build (which is hyperlinked).</li>
 /// <li>Any diagnostics generated for that project.</li>
 /// </ul>
-/// This option is available starting in .NET 8.
 /// </summary>
+/// <remarks>This option is available starting in .NET 8.</remarks>
 [<RequireQualifiedAccess>]
 type MSBuildTerminalLoggerOption =
     | On

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
@@ -6,6 +6,19 @@ open Expecto
 
 [<Tests>]
 let tests =
+    let flagsTestCase name changeBuildArgs expected =
+        testCase name
+        <| fun _ ->
+            let _, cmdLine = MSBuild.buildArgs changeBuildArgs
+
+            let expected =
+                if Environment.isUnix then
+                    $"{expected} /p:RestorePackages=False".Trim()
+                else
+                    $"{expected} /m /nodeReuse:False /p:RestorePackages=False".Trim()
+
+            Expect.equal cmdLine expected $"Expected a given cmdLine '{expected}', but got '{cmdLine}'."
+
     testList
         "Fake.DotNet.MSBuild.Tests"
         [ testCase "Test that we can create simple msbuild cmdline"
@@ -37,4 +50,18 @@ let tests =
                   else
                       "/restore /m /nodeReuse:False /p:RestorePackages=False"
 
-              Expect.equal cmdLine expected "Expected a given cmdline." ]
+              Expect.equal cmdLine expected "Expected a given cmdline."
+
+          flagsTestCase "/tl:auto doesn't ouput anything (1)" id ""
+          flagsTestCase
+              "/tl:auto doesn't ouput anything (2)"
+              (fun args -> { args with TerminalLogger = MSBuildTerminalLoggerOption.Auto })
+              ""
+          flagsTestCase
+              "/tl:on does ouput"
+              (fun args -> { args with TerminalLogger = MSBuildTerminalLoggerOption.On })
+              "/tl:on"
+          flagsTestCase
+              "/tl:off does ouput"
+              (fun args -> { args with TerminalLogger = MSBuildTerminalLoggerOption.Off })
+              "/tl:off" ]

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
@@ -12,6 +12,12 @@ let tests =
             let _, cmdLine = MSBuild.buildArgs changeBuildArgs
 
             let expected =
+                if BuildServer.ansiColorSupport then
+                    $"%s{expected} /clp:ForceConsoleColor".Trim()
+                else
+                    expected.Trim()
+                    
+            let expected =
                 if Environment.isUnix then
                     $"{expected} /p:RestorePackages=False".Trim()
                 else

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
@@ -16,7 +16,7 @@ let tests =
                     $"%s{expected} /clp:ForceConsoleColor".Trim()
                 else
                     expected.Trim()
-                    
+
             let expected =
                 if Environment.isUnix then
                     $"{expected} /p:RestorePackages=False".Trim()

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
@@ -21,7 +21,7 @@ let tests =
                 if Environment.isUnix then
                     $"{expected} /p:RestorePackages=False".Trim()
                 else
-                    $"{expected} /m /nodeReuse:False /p:RestorePackages=False".Trim()
+                    $"/m /nodeReuse:False {expected} /p:RestorePackages=False".Trim()
 
             Expect.equal cmdLine expected $"Expected a given cmdLine '{expected}', but got '{cmdLine}'."
 


### PR DESCRIPTION
### Description
see `--tl:[auto|on|off]` on `dotnet build` documentation: https://learn.microsoft.com/en-gb/dotnet/core/tools/dotnet-build

Since this only works with dotnet sdk >= 8, the default case (specifying `Auto`) will not emit the tag.


## TODO

Feel free to open the PR and ask for help

- [ ] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [x] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [ ] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [ ] (if new module) the module has been linked from the "side navigation" menu, edit `docs/data.json`.
- [ ] (if new module) the module is in the correct namespace.
- [ ] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [ ] Fake [API guideline](https://fake.build/guide/contributing.html#API-Design-Guidelines) is honored
