### PR TITLE
Msbuild max cpu

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+
+* BUGFIX: Allow settting Msbuild max cpu on Linux, thanks @TheAngryByrd - https://github.com/fsprojects/FAKE/pull/2772
+
 ## 6.0.1 - 2024-06-04
 * BUGFIX: MSBuild.build adds a bad string at the end of properties, thanks @0x53A - https://github.com/fsprojects/FAKE/issues/2738
 * ENHANCEMENT: Added shorthash to git functions, thanks @voronoipotato - https://github.com/fsprojects/FAKE/pull/2752

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -855,10 +855,9 @@ module MSBuild =
 
         [ yield restoreFlag
           yield targets
-          if not Environment.isUnix then
-              yield maxCpu
-              yield noLogo
-              yield nodeReuse
+          yield maxCpu
+          yield noLogo
+          yield nodeReuse
           yield tools
           yield verbosity
           yield noConsoleLogger

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
@@ -17,10 +17,7 @@ let tests =
                           Properties = [ "OutputPath", "C:\\Test\\" ] })
 
               let expected =
-                  if Environment.isUnix then
-                      "/p:RestorePackages=False /p:OutputPath=C:%5CTest%5C"
-                  else
-                      "/m /nodeReuse:False /p:RestorePackages=False /p:OutputPath=C:%5CTest%5C"
+                  "/m /nodeReuse:False /p:RestorePackages=False /p:OutputPath=C:%5CTest%5C"
 
               Expect.equal cmdLine expected "Expected a given cmdline."
           testCase "Test that /restore is included #2160"
@@ -31,10 +28,6 @@ let tests =
                           ConsoleLogParameters = []
                           DoRestore = true })
 
-              let expected =
-                  if Environment.isUnix then
-                      "/restore /p:RestorePackages=False"
-                  else
-                      "/restore /m /nodeReuse:False /p:RestorePackages=False"
+              let expected = "/restore /m /nodeReuse:False /p:RestorePackages=False"
 
               Expect.equal cmdLine expected "Expected a given cmdline." ]


### PR DESCRIPTION
### Description

Allows properties like MaxCpuCount to be used on unix.

Mostly checking CI to see if it breaks something.

If available, link to an existing issue this PR fixes. For example:



## TODO

Feel free to open the PR and ask for help

- [ ] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [ ] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [ ] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [ ] (if new module) the module has been linked from the "side navigation" menu, edit `docs/data.json`.
- [ ] (if new module) the module is in the correct namespace.
- [ ] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [ ] Fake [API guideline](https://fake.build/guide/contributing.html#API-Design-Guidelines) is honored
