### PR TITLE
Try running the macOS CI builds on macOS 13

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ubuntu-latest, windows-latest, macOS-latest]
+                os: [ubuntu-latest, windows-latest, macOS-13]
         steps:
             - uses: actions/checkout@v4
             - name: Setup .NET 6


### PR DESCRIPTION
Just seeing if it has any effect on the intermittent macOS CI issues really - as per the github docs at https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources 'macOS-latest' actually uses macOS 12, and the macOS 13 runner also has more CPU cores than the 12 runner