### PR TITLE
Parse references at end of changelog as separate part of a changelog.

### DIFF
--- a/src/app/Fake.Core.ReleaseNotes/Changelog.fs
+++ b/src/app/Fake.Core.ReleaseNotes/Changelog.fs
@@ -389,7 +389,7 @@ module Changelog =
             let references =
                 x.References |> List.map (fun reference -> reference.ToString()) |> joinLines
 
-            (sprintf "# %s\n\n%s\n\n%s\n\n%s" header description entries references)
+            $"# {header}\n\n{description}\n\n{entries}\n\n{references}"
             |> fixMultipleNewlines
             |> String.trim
 


### PR DESCRIPTION
### Description

The references to tags or `compare` links at the end of a changelog file are parsed into a separate member of the `Changelog` record. Before, lines like

```
[Unreleased]: https://github.com/user/MyCoolNewLib.git/compare/v0.1.0...HEAD
[0.1.0]: https://github.com/user/MyCoolNewLib.git/releases/tag/v0.1.0
```

ended up in the `Changes` list of the last `ChangelogEntry`. In certain situations, this lead to undesired modifications by `PromoteUnreleased` since these reference lines were reproduced in a release entry.

When saving and converting a `Changelog` to a string, these references are also included as the last lines of the changeling file.
