### PR TITLE
Update the .NET SDK in the CI builds to 6.0.300

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Setup .NET 6
               uses: actions/setup-dotnet@v4
               with:
-                  dotnet-version: '6.0.101'
+                  dotnet-version: '6.0.300'
             - name: Restore dotnet tools
               run: dotnet tool restore
             - name: remove current fake runner tool

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
             - name: Setup .NET 6
               uses: actions/setup-dotnet@v4
               with:
-                  dotnet-version: '6.0.101'
+                  dotnet-version: '6.0.300'
             - name: Restore dotnet tools
               run: dotnet tool restore
             - name: remove current fake runner tool

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
-    "sdk" : {
-        "version": "6.0.101",
+    "sdk": {
+        "version": "6.0.300",
         "rollForward": "latestMinor"
     }
 }


### PR DESCRIPTION
### Description

A minimal update to the .NET 6 SDK version, to see if it fixes the macOS/ARM CI failures discussed in https://github.com/fsprojects/FAKE/pull/2778