### PR TITLE
Update the upload-artifact CI build action to version 4

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,7 +27,7 @@ jobs:
             - name: Build
               run: dotnet fake build --parallel 3
             - name: publish build artifacts
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
-                  name: fake-artifacts
+                  name: fake-artifacts-${{ matrix.os }}
                   path: release/artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
             - name: Build
               run: dotnet fake build -t Release_BuildAndTest --parallel 3
             - name: publish build artifacts
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: fake-artifacts
                   path: release/artifacts


### PR DESCRIPTION
In the current CI builds, there are a number of instances of this warning:

![image](https://github.com/user-attachments/assets/34bc42e4-24c0-4c63-aa8d-9e3a9ec4678c)

In addition, the documentation at https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ documents that the v3 action will be deprecated and not useable later this year.

That doc also says ```While v4 of the artifact actions improves upload and download speeds by up to 98% ``` which may or may not effect the intermittent artifact upload timeout that has caused the CI builds to fail a few times recently.
