### PR TITLE
Msbuild max cpu (updated)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## 6.1.0 - 2024-07-27
 * BUGFIX: MSBuild.build adds a bad string at the end of properties, thanks @0x53A - https://github.com/fsprojects/FAKE/issues/2738
+* BUGFIX: Allow setting Msbuild max cpu on Linux, thanks @TheAngryByrd - https://github.com/fsprojects/FAKE/pull/2772
 * ENHANCEMENT: Added shorthash to git functions, thanks @voronoipotato - https://github.com/fsprojects/FAKE/pull/2752
 * ENHANCEMENT: Support for `/tl:[auto:on:off]` msbuild flag, thanks @smoothdeveloper - https://github.com/fsprojects/FAKE/pull/2768
 * ENHANCEMENT: Fixes for usage in .NET 8.0 enviroment projects.

--- a/src/app/Fake.DotNet.MSBuild/MSBuild.fs
+++ b/src/app/Fake.DotNet.MSBuild/MSBuild.fs
@@ -885,10 +885,9 @@ module MSBuild =
 
         [ yield restoreFlag
           yield targets
-          if not Environment.isUnix then
-              yield maxCpu
-              yield noLogo
-              yield nodeReuse
+          yield maxCpu
+          yield noLogo
+          yield nodeReuse
           yield
               (match p.TerminalLogger with
                | MSBuildTerminalLoggerOption.Off -> Some("tl", "off")

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
@@ -36,10 +36,7 @@ let tests =
                           Properties = [ "OutputPath", "C:\\Test\\" ] })
 
               let expected =
-                  if Environment.isUnix then
-                      "/p:RestorePackages=False /p:OutputPath=C:%5CTest%5C"
-                  else
-                      "/m /nodeReuse:False /p:RestorePackages=False /p:OutputPath=C:%5CTest%5C"
+                  "/m /nodeReuse:False /p:RestorePackages=False /p:OutputPath=C:%5CTest%5C"
 
               Expect.equal cmdLine expected "Expected a given cmdline."
           testCase "Test that /restore is included #2160"
@@ -50,11 +47,7 @@ let tests =
                           ConsoleLogParameters = []
                           DoRestore = true })
 
-              let expected =
-                  if Environment.isUnix then
-                      "/restore /p:RestorePackages=False"
-                  else
-                      "/restore /m /nodeReuse:False /p:RestorePackages=False"
+              let expected = "/restore /m /nodeReuse:False /p:RestorePackages=False"
 
               Expect.equal cmdLine expected "Expected a given cmdline."
 

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
@@ -17,11 +17,7 @@ let tests =
                 else
                     expected.Trim()
 
-            let expected =
-                if Environment.isUnix then
-                    $"{expected} /p:RestorePackages=False".Trim()
-                else
-                    $"/m /nodeReuse:False {expected} /p:RestorePackages=False".Trim()
+            let expected = $"/m /nodeReuse:False {expected} /p:RestorePackages=False".Trim()
 
             Expect.equal cmdLine expected $"Expected a given cmdLine '{expected}', but got '{cmdLine}'."
 


### PR DESCRIPTION
As #2772 except

1. Updated on top of the latest master to fix conflicts
2. Updates a new unit test added in #2768 to no longer expect different results on Unix/NotUnix