### PR TITLE
Paket.dependencies: Allow Paket.Core to be in pre-release version to get the integration-tests pass.

### DIFF
--- a/integrationtests/core-no-dependencies-hello-world/before/paket.dependencies
+++ b/integrationtests/core-no-dependencies-hello-world/before/paket.dependencies
@@ -7,3 +7,4 @@ source https://ci.appveyor.com/nuget/fake
 
 nuget Fake.Runtime prerelease
 nuget FSharp.Core prerelease
+nuget Paket.Core prerelease

--- a/integrationtests/core-reference-assemblies-net60101-rollforward/before/reference-assemblies.fsx
+++ b/integrationtests/core-reference-assemblies-net60101-rollforward/before/reference-assemblies.fsx
@@ -3,7 +3,8 @@ storage: none
 source https://api.nuget.org/v3/index.json
 source ../../../release/dotnetcore
 nuget Fake.Runtime prerelease
-nuget FSharp.Core prerelease"
+nuget FSharp.Core prerelease
+nuget Paket.Core prerelease"
 
 open Fake.Runtime
 

--- a/integrationtests/core-reference-assemblies-net60101/before/reference-assemblies.fsx
+++ b/integrationtests/core-reference-assemblies-net60101/before/reference-assemblies.fsx
@@ -3,7 +3,8 @@ storage: none
 source https://api.nuget.org/v3/index.json
 source ../../../release/dotnetcore
 nuget Fake.Runtime prerelease
-nuget FSharp.Core prerelease"
+nuget FSharp.Core prerelease
+nuget Paket.Core prerelease"
 
 open Fake.Runtime
 

--- a/integrationtests/core-reference-fake-core-targets/before/reference_fake-targets.fsx
+++ b/integrationtests/core-reference-fake-core-targets/before/reference_fake-targets.fsx
@@ -5,7 +5,8 @@ source ../../../release/dotnetcore
 
 nuget Fake.Core.Target prerelease
 nuget System.Reactive.Compatibility
-nuget FSharp.Core prerelease"
+nuget FSharp.Core prerelease
+nuget Paket.Core prerelease"
 #endif
 
 printfn "before load"

--- a/integrationtests/core-reference-fake-runtime/before/reference_fake-runtime.fsx
+++ b/integrationtests/core-reference-fake-runtime/before/reference_fake-runtime.fsx
@@ -6,7 +6,8 @@ source ../../../release/dotnetcore
 //source https://ci.appveyor.com/nuget/paket
 
 nuget Fake.Runtime prerelease
-nuget FSharp.Core prerelease"
+nuget FSharp.Core prerelease
+nuget Paket.Core prerelease"
 #endif
 #load ".fake/reference_fake-runtime.fsx/intellisense.fsx"
 

--- a/integrationtests/core-simple-failed-to-compile/before/fail-to-compile.fsx
+++ b/integrationtests/core-simple-failed-to-compile/before/fail-to-compile.fsx
@@ -5,7 +5,8 @@ source ../../../release/dotnetcore
 //source https://ci.appveyor.com/nuget/paket
 
 nuget Fake.Runtime prerelease
-nuget FSharp.Core prerelease"
+nuget FSharp.Core prerelease
+nuget Paket.Core prerelease"
 #endif
 open klajsdhgfasjkhd
 

--- a/integrationtests/core-simple-runtime-error/before/runtime-error.fsx
+++ b/integrationtests/core-simple-runtime-error/before/runtime-error.fsx
@@ -5,6 +5,7 @@
 #r "paket: //source https://ci.appveyor.com/nuget/paket"
 #r "paket: nuget Fake.Runtime prerelease"
 #r "paket: nuget FSharp.Core prerelease"
+#r "paket: nuget Paket.Core prerelease"
 #endif
 
 // Issue https://github.com/fsharp/FAKE/issues/2121

--- a/integrationtests/core-use-external-paket-dependencies/before/paket.dependencies
+++ b/integrationtests/core-use-external-paket-dependencies/before/paket.dependencies
@@ -6,3 +6,4 @@ source ../../../release/dotnetcore
 nuget Fake.Runtime prerelease
 nuget FSharp.Core prerelease
 nuget Microsoft.NETCore.App
+nuget Paket.Core prerelease

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -55,7 +55,7 @@ group fakemodule
     nuget FParsec
     nuget Octokit
     nuget Newtonsoft.Json
-    nuget Paket.Core 8.1.0-alpha004
+    nuget Paket.Core prerelease
     nuget NuGet.Protocol
     nuget NuGet.Packaging
     nuget Mono.Cecil prerelease

--- a/src/test/Fake.Core.IntegrationTests/SimpleHelloWorldTests.fs
+++ b/src/test/Fake.Core.IntegrationTests/SimpleHelloWorldTests.fs
@@ -249,7 +249,7 @@ let tests =
                       "Expected correct declaration of 'Start'"
                       { Declaration.Empty with
                           File = scriptFile
-                          Line = 36 }
+                          Line = 37 }
                       startTarget.Declaration
 
                   Expect.equal "Expected correct hard dependencies of 'Start'" [] startTarget.HardDependencies
@@ -261,7 +261,7 @@ let tests =
                       "Expected correct declaration of 'TestTarget'"
                       { Declaration.Empty with
                           File = scriptFile
-                          Line = 38 }
+                          Line = 39 }
                       testTarget.Declaration
 
                   Expect.equal
@@ -270,7 +270,7 @@ let tests =
                           Declaration =
                             { Declaration.Empty with
                                 File = scriptFile
-                                Line = 45 } } ]
+                                Line = 46 } } ]
                       testTarget.HardDependencies
 
                   Expect.equal "Expected correct description of 'TestTarget'" "" testTarget.Description

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
@@ -6,16 +6,17 @@ open Expecto
 
 [<Tests>]
 let tests =
-    let flagsTestCase name changeBuildArgs expected =
+    let flagsTestCase name changeBuildArgs (expected:string) =
         testCase name
         <| fun _ ->
             let _, cmdLine = MSBuild.buildArgs changeBuildArgs
 
             let expected =
+                let trimmed = expected.Trim()
                 if BuildServer.ansiColorSupport then
-                    $"%s{expected} /clp:ForceConsoleColor".Trim()
+                    $"%s{trimmed} /clp:ForceConsoleColor".Trim()
                 else
-                    expected.Trim()
+                    trimmed
 
             let expected = $"/m /nodeReuse:False {expected} /p:RestorePackages=False".Trim()
 

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
@@ -6,13 +6,14 @@ open Expecto
 
 [<Tests>]
 let tests =
-    let flagsTestCase name changeBuildArgs (expected:string) =
+    let flagsTestCase name changeBuildArgs (expected: string) =
         testCase name
         <| fun _ ->
             let _, cmdLine = MSBuild.buildArgs changeBuildArgs
 
             let expected =
                 let trimmed = expected.Trim()
+
                 if BuildServer.ansiColorSupport then
                     $"%s{trimmed} /clp:ForceConsoleColor".Trim()
                 else


### PR DESCRIPTION

The integration test problem of:
https://github.com/fsprojects/FAKE/actions/runs/10130599307/job/28012174301#step:8:7798

What is happening: The FSharp.Core cannot be found that would satisfy requirement of both FSharp.Compiler.Service 43 and Paket.Core. 

Fix: Paket.Core pre-release version has to be allowed. Then Paket can found a common version that works for both.
