### PR TITLE
Make tests more durable

### DIFF
--- a/src/test/Fake.Core.IntegrationTests/TestHelpers.fs
+++ b/src/test/Fake.Core.IntegrationTests/TestHelpers.fs
@@ -97,7 +97,12 @@ let prepare scenario =
     let scenarioPath = scenarioTempPath scenario
 
     if Directory.Exists scenarioPath then
-        Directory.Delete(scenarioPath, true)
+        try
+            Directory.Delete(scenarioPath, true)
+        with _ -> // Maybe locked. Let's sleep and retry.
+            System.Threading.Thread.Sleep 5000
+            Directory.Delete(scenarioPath, true)
+            ()
 
     Directory.ensure scenarioPath
 

--- a/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.DotNet.MSBuild.fs
@@ -12,7 +12,7 @@ let tests =
             let _, cmdLine = MSBuild.buildArgs changeBuildArgs
 
             let expected =
-                let trimmed = expected.Trim()
+                let trimmed = expected.Replace("  ", " ").Trim()
 
                 if BuildServer.ansiColorSupport then
                     $"%s{trimmed} /clp:ForceConsoleColor".Trim()
@@ -21,7 +21,10 @@ let tests =
 
             let expected = $"/m /nodeReuse:False {expected} /p:RestorePackages=False".Trim()
 
-            Expect.equal cmdLine expected $"Expected a given cmdLine '{expected}', but got '{cmdLine}'."
+            Expect.equal
+                (cmdLine.Replace("  ", " "))
+                (expected.Replace("  ", " "))
+                $"Expected a given cmdLine '{expected}', but got '{cmdLine}'."
 
     testList
         "Fake.DotNet.MSBuild.Tests"
@@ -36,7 +39,7 @@ let tests =
               let expected =
                   "/m /nodeReuse:False /p:RestorePackages=False /p:OutputPath=C:%5CTest%5C"
 
-              Expect.equal cmdLine expected "Expected a given cmdline."
+              Expect.equal (cmdLine.Replace("  ", " ")) (expected.Replace("  ", " ")) "Expected a given cmdline."
           testCase "Test that /restore is included #2160"
           <| fun _ ->
               let _, cmdLine =
@@ -47,7 +50,7 @@ let tests =
 
               let expected = "/restore /m /nodeReuse:False /p:RestorePackages=False"
 
-              Expect.equal cmdLine expected "Expected a given cmdline."
+              Expect.equal (cmdLine.Replace("  ", " ")) (expected.Replace("  ", " ")) "Expected a given cmdline."
 
           flagsTestCase "/tl:auto doesn't ouput anything (1)" id ""
           flagsTestCase

--- a/src/test/Fake.Core.UnitTests/Fake.Runtime.fs
+++ b/src/test/Fake.Core.UnitTests/Fake.Runtime.fs
@@ -127,7 +127,7 @@ nuget Fake.Core.SemVer prerelease //"
                   Fake.Runtime.FSharpParser.getTokenized
                       "testfile.fsx"
                       [ "BOOTSTRAP"; "DOTNETCORE"; "FAKE" ]
-                      (scriptText.Split([| '\r'; '\n' |]))
+                      (scriptText.Replace("\r\n", "\n").Split([| '\r'; '\n' |]))
                   |> Fake.Runtime.FSharpParser.findInterestingItems
 
               let expected =
@@ -152,7 +152,7 @@ nuget Fake.Core.SemVer prerelease //"
                   Fake.Runtime.FSharpParser.getTokenized
                       "testfile.fsx"
                       [ "DOTNETCORE"; "FAKE" ]
-                      (scriptText.Split([| '\r'; '\n' |]))
+                      (scriptText.Replace("\r\n", "\n").Split([| '\r'; '\n' |]))
                   |> Fake.Runtime.FSharpParser.findInterestingItems
 
               let expected = []
@@ -193,7 +193,7 @@ nuget Fake.Core.SemVer prerelease //"
                       Fake.Runtime.FSharpParser.getTokenized
                           "build.fsx"
                           [ "DOTNETCORE"; "FAKE" ]
-                          (scriptText.Split([| '\r'; '\n' |]))
+                          (scriptText.Replace("\r\n", "\n").Split([| '\r'; '\n' |]))
 
                   let scripts = HashGeneration.getAllScripts true [] tokens (tmpDir </> "build.fsx")
 
@@ -245,7 +245,7 @@ printfn "other.fsx"
                       Fake.Runtime.FSharpParser.getTokenized
                           "test.fsx"
                           [ "DOTNETCORE"; "FAKE" ]
-                          (testScript.Split([| '\r'; '\n' |]))
+                          (testScript.Replace("\r\n", "\n").Split([| '\r'; '\n' |]))
 
                   let scripts = HashGeneration.getAllScripts true [] tokens testScriptPath
                   let expected = [ testScriptPath; fileScriptPath; otherScriptPath ]
@@ -272,7 +272,7 @@ printfn "other.fsx"
                       Fake.Runtime.FSharpParser.getTokenized
                           "test.fsx"
                           [ "DOTNETCORE"; "FAKE" ]
-                          (testScript.Split([| '\r'; '\n' |]))
+                          (testScript.Replace("\r\n", "\n").Split([| '\r'; '\n' |]))
 
                   try
                       let scripts = HashGeneration.getAllScripts true [] tokens testScriptPath


### PR DESCRIPTION
Current tests seems to fail easily if:

- The file is in use. We could just wait a second and retry
- The environment line-breaks are different than expected `\n` vs `\r\n`. There is an existing pattern of trying to deal with it by doing `.Split([| '\r'; '\n' |])` however that causes `\r\n` to be converted to 2 lines instead of one. After that all the test that are annoyingly expecting line-numbers like "test.fsx line 2: Failed" are off-by-one.
- The command line arguments having sometimes a double-space by accident. No-one should care.

