### PR TITLE
Remove `Version.Parse` check from `global.json` parsing

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## 6.1.1 - 2024-08-19
 * BUGFIX: Assembly resolver to pick a found SDK instead of first SDK - https://github.com/fsprojects/FAKE/pull/2797/files
+* BUGFIX: Fix issue parsing global.json when using prerelease .NET SDKs, thanks @numpsy - https://github.com/fsprojects/FAKE/issues/2803
 
 ## 6.1.0 - 2024-07-27
 * BUGFIX: MSBuild.build adds a bad string at the end of properties, thanks @0x53A - https://github.com/fsprojects/FAKE/issues/2738

--- a/src/app/Fake.DotNet.Cli/DotNet.fs
+++ b/src/app/Fake.DotNet.Cli/DotNet.fs
@@ -69,10 +69,7 @@ module DotNet =
 
                 match sdk.Property("version") with
                 | null -> None
-                | version ->
-                    let versionValue = version.Value.ToString()
-                    let _ = Version.Parse(versionValue)
-                    Some versionValue
+                | version -> Some(version.Value.ToString())
             with exn ->
                 failwithf "Could not parse `sdk.version` from global.json at '%s': %s" globalJson.FullName exn.Message
 


### PR DESCRIPTION
refs #2803 - The check seems to break if the version is a pre-release version such as ```9.0.100-preview.6.24328.19```

The Parse call was added as part of the null change in #2757 but i'm not sure if there was any reason for it other than an attempt at a sanity check?

(needs release notes if it the change is ok)