### PR TITLE
Try specifying the access token with `x-access-token` when pushing GitHub pages

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -994,7 +994,7 @@ Target.create "DotNetPushToNuGet" (fun _ ->
 
 Target.create "ReleaseDocs" (fun _ ->
     Shell.cleanDir "gh-pages"
-    let auth = sprintf "%s:x-oauth-basic@" githubToken.Value
+    let auth = sprintf "x-access-token:%s@" githubToken.Value
     let url = sprintf "https://%sgithub.com/%s/%s.git" auth githubReleaseUser gitName
     Git.Repository.cloneSingleBranch "" url "gh-pages" "gh-pages"
 


### PR DESCRIPTION
refs https://github.com/fsprojects/FAKE/pull/2802#issuecomment-2297099404

I don't have a means of testing this, it's just a guess based on some of the Github actions for pushing pages, e.g.

https://github.com/peaceiris/actions-gh-pages/blob/0b7567fde6f7517edcc13d8ffa2d89cd8734d47c/src/set-tokens.ts#L100

https://github.com/EdricChan03/action-build-deploy-ghpages/blob/3183472d918d9ea82237bf4f2c416e5c8c13a394/entrypoint.sh#L32