### PR TITLE
Try pinning Octokit to v6.0.0 in build.fsx

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -41,7 +41,7 @@ nuget System.Reactive.Compatibility
 nuget Suave
 nuget Newtonsoft.Json
 nuget System.Net.Http
-nuget Octokit
+nuget Octokit 6.0.0
 nuget Microsoft.Deployment.DotNet.Releases //"
 
 open System.Reflection


### PR DESCRIPTION
I think (/am guessing) that the error in the release build at https://github.com/fsprojects/FAKE/actions/runs/10605838278/job/29395428955#step:10:618 is because the Paket restore for build.fsx is restoring version 13 of Octokit, along side a release package of Fake.Api.GitHub which doesn't work with that version due to breaking API changes, and that's causing problems.

So - try pinning the Octokit nuget reference in build.fsx to 6.0.0 to match the released FAKE packages.