### PR TITLE
Build.fsx: Use `Git.Repository.fullClean` instead of `Git.Repository.fullclean`

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -1002,7 +1002,7 @@ Target.create "ReleaseDocs" (fun _ ->
     let url = sprintf "https://%sgithub.com/%s/%s.git" auth githubReleaseUser gitName
     Git.Repository.cloneSingleBranch "" url "gh-pages" "gh-pages"
 
-    Git.Repository.fullclean "gh-pages"
+    Git.Repository.fullClean "gh-pages"
 
     Shell.copyRecursive "output" "gh-pages" true |> printfn "%A"
 


### PR DESCRIPTION
### Description

When looking at other things, I noticed that the build.fsx directory in my FAKE build contained a .warning file that contained
```
build.fsx (1004,4)-(1004,28): Warning FS0044: This construct is deprecated. Please use fullClean instead. This method will be removed in FAKE next major release
```
So - any reason to not change it to the not-deprecated function?