### PR TITLE
build.fsx: Reference System.Reactive instead of System.Reactive.Compa…

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -37,7 +37,7 @@ nuget Fake.Windows.Chocolatey prerelease
 nuget Fake.JavaScript.Npm prerelease
 nuget Fake.Tools.Git prerelease
 nuget Mono.Cecil prerelease
-nuget System.Reactive.Compatibility
+nuget System.Reactive
 nuget Suave
 nuget Newtonsoft.Json
 nuget System.Net.Http


### PR DESCRIPTION
…tibility

### Description

Another observation whist looking at other things - build.fsx references the System.Reactive.Compatibility NuGet package and I don't see why -

The nuget.org listing for the package says ```This package exists for backwards compatibility, and should not be used by new applications.``` and it also depends on quite a few other System.Reactive.* packages that don't seem to be used.

The only use of System.Reactive that I see in the Fake build is in Fake.Core.Target (via FSharp.Control.Reactive) and the reference in build.fsx does seem to update the reference in the CI build from 5.0 to 6.0.1, but that can be done just by updating System.Reactive directly.

So - could it be changed to simplify the build dependencies?
