### PR TITLE
Fix a FS3548 'Pattern discard is not allowed for union case that takes no data.' compiler warning

### DIFF
--- a/src/app/Fake.DotNet.Cli/CreateProcessExt.fs
+++ b/src/app/Fake.DotNet.Cli/CreateProcessExt.fs
@@ -156,7 +156,7 @@ module CreateProcessDotNetExt =
         /// </example>
         let withToolType (toolType: ToolType) (c: CreateProcess<_>) =
             match toolType with
-            | ToolType.FullFramework _ -> c |> CreateProcess.withFramework
+            | ToolType.FullFramework -> c |> CreateProcess.withFramework
             | ToolType.FrameworkDependentDeployment dotnetOptions -> // dotnet ToolPath (can be a dll)
                 c |> DotNet.prefixProcess dotnetOptions.Options [ c.Command.Executable ]
             | ToolType.SelfContainedDeployment // just ToolPath


### PR DESCRIPTION
### Description

```ToolType.FullFramework``` has no payload, so it shouldn't need the discard
