### PR TITLE
Some maintenance updates to help upcoming .NET 8 migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,4 +49,4 @@ jobs:
                   RELEASE_USER_GITHUB: ${{ secrets.RELEASE_USER_GITHUB }}
                   REPOSITORY_NAME_GITHUB: ${{ secrets.REPOSITORY_NAME_GITHUB }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: ${{github.workspace}}/release/dotnetcore/Fake.netcore/win7-x64/fake.exe build -t FastRelease
+              run: ${{github.workspace}}/release/dotnetcore/Fake.netcore/win-x64/fake.exe build -t FastRelease

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
 # Release Notes
+## 6.1.2 - 2024-09-20
+* Runtime-identifier update to more recent runtimes.
+* Removed .NETFrameworkAssembly attribute fix on detecting .NET assemblies.
 
 ## 6.1.1 - 2024-08-30
 * BUGFIX: Assembly resolver to pick a found SDK instead of first SDK, thanks @Thorium - https://github.com/fsprojects/FAKE/pull/2797/files

--- a/build.fsx
+++ b/build.fsx
@@ -425,7 +425,7 @@ docker run --rm -v $PWD:$PWD -w $PWD linuturk/mono-choco $@
     altToolPath
 
 //TODO:: see if we need to update the runtimes to newer versions of OSs
-let runtimes = [ "win7-x86"; "win7-x64"; "osx.10.11-x64"; "linux-x64" ]
+let runtimes = [ "win-x86"; "win-x64"; "osx-x64"; "linux-x64" ]
 
 /// <summary>
 /// Publishes the build artifacts for the given runtime
@@ -809,7 +809,10 @@ runtimes
                     { c with
                         Runtime = Some runtime.Value
                         Configuration = DotNet.Release
-                        OutputPath = Some outDir }
+                        OutputPath = Some outDir 
+                        Framework = Some "net6.0"
+                        // DisableInternalBinLog: https://github.com/fsprojects/FAKE/issues/2722
+                        MSBuildParams = { MSBuild.CliArguments.Create() with DisableInternalBinLog = true }}
                     |> dotnetSimple)
                 proj
 
@@ -876,7 +879,9 @@ Target.create "DotNetCreateNuGetPackage" (fun _ ->
                     { c.MSBuildParams with
                         Properties =
                             [ ("Version", nugetVersion)
-                              ("PackageReleaseNotes", release.Notes |> String.toLines) ] } }
+                              ("PackageReleaseNotes", release.Notes |> String.toLines) ] 
+                        // DisableInternalBinLog: https://github.com/fsprojects/FAKE/issues/2722
+                        DisableInternalBinLog = true } }
             |> dotnetSimple)
         "Fake.sln"
 
@@ -916,7 +921,7 @@ Target.create "DotNetCreateChocolateyPackage" (fun _ ->
                 InstallerType = Choco.ChocolateyInstallerType.SelfContained
                 Version = chocoVersion
                 Files =
-                    [ System.IO.Path.GetFullPath(nugetDncDir </> @"Fake.netcore\win7-x86") + @"\**", Some "bin", None
+                    [ System.IO.Path.GetFullPath(nugetDncDir </> @"Fake.netcore\win-x86") + @"\**", Some "bin", None
                       (System.IO.Path.GetFullPath @"src\VERIFICATION.txt"), Some "VERIFICATION.txt", None
                       (System.IO.Path.GetFullPath @"License.txt"), Some "LICENSE.txt", None ]
                 OutputDir = chocoReleaseDir }

--- a/docs/guide/buildserver.md
+++ b/docs/guide/buildserver.md
@@ -84,7 +84,7 @@ Fake itself uses `GitHubActions` support for importing and displaying test resul
 Trace.publish (ImportData.Nunit NunitDataVersion.Nunit) "Fake_Core_CommandLine_UnitTests.TestResults.xml"
 
 // upload artifacts
-Trace.publish ImportData.BuildArtifact ("release/dotnetcore/fake-dotnetcore-win7-x64.zip")
+Trace.publish ImportData.BuildArtifact ("release/dotnetcore/fake-dotnetcore-win-x64.zip")
 ```
 
 Also, prior to currently setup of FAKE which uses GitHub actions. The previous setup used VSTS (Azure DevOps)

--- a/docs/guide/dotnet-cli.md
+++ b/docs/guide/dotnet-cli.md
@@ -40,7 +40,7 @@ DotNet.restore (fun args ->
 // Define more general properties in addition to the general ones, with arugments
 DotNet.restore (fun args ->
     { args with
-        Runtime = Some "win7-x86"
+        Runtime = Some "win-x86"
     } |> withWorkDir "./test" ) "mysolution.sln"
 ```
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -215,7 +215,7 @@ There are various ways to install FAKE:
 
 5. Download the runtime specific zip.
    Just use the `-<runtime>` version matching your specific platform
-   of [<ins>the downloads</ins>](https://github.com/fsharp/FAKE/releases) (for example `fake-dotnetcore-win7-x64.zip`),
+   of [<ins>the downloads</ins>](https://github.com/fsharp/FAKE/releases) (for example `fake-dotnetcore-win-x64.zip`),
    extract it and execute the `fake` binary. Add the extracted binary to your `PATH` to just execute `fake` from any
    directory.
 

--- a/src/VERIFICATION.txt
+++ b/src/VERIFICATION.txt
@@ -4,4 +4,4 @@ in verifying that this package's contents are trustworthy.
  
 This package is published by the FAKE Project itself. Any binaries will be 
 identical to other package types published by the project, in particular
-the fake-dotnetcore-win7-x86.zip binary release.
+the fake-dotnetcore-win-x86.zip binary release.

--- a/src/app/Fake.Core.String/String.fs
+++ b/src/app/Fake.Core.String/String.fs
@@ -275,4 +275,4 @@ module String =
         /// <summary>
         /// Determines if a text matches a given regex pattern.
         /// </summary>
-        let (>**) pattern text = (getRegEx pattern).IsMatch text
+        let (>**) pattern (text: string) = (getRegEx pattern).IsMatch text

--- a/src/app/Fake.IO.FileSystem/Path.fs
+++ b/src/app/Fake.IO.FileSystem/Path.fs
@@ -35,7 +35,7 @@ module Path =
     /// </summary>
     ///
     /// <param name="path">The path to check</param>
-    let isDirectory path =
+    let isDirectory (path: string) =
         let attr = File.GetAttributes path
         attr &&& FileAttributes.Directory = FileAttributes.Directory
 

--- a/src/app/Fake.Net.FTP/FTP.fs
+++ b/src/app/Fake.Net.FTP/FTP.fs
@@ -99,7 +99,7 @@ module FTP =
         List.forall (fun validator -> directoryName |> validator) validators
 
     /// Checks to see if the `ftp content` string contains the string `Given_Folder_Name`
-    let inline regexCheck folderName ftpContents =
+    let inline regexCheck folderName (ftpContents: string) =
         Regex.IsMatch(ftpContents, $@"\s+%s{folderName}\s+")
 
     /// <summary>

--- a/src/app/Fake.Runtime/CoreCache.fs
+++ b/src/app/Fake.Runtime/CoreCache.fs
@@ -332,7 +332,9 @@ let findAndLoadInRuntimeDeps
 
                     let isFramework =
                         assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
-                        |> Seq.exists (fun m -> m.Key = ".NETFrameworkAssembly")
+                        |> Seq.exists (fun m ->
+                            m.Key = ".NETFrameworkAssembly" // net8.0 framework assemblies have NETFrameworkAssembly attribute removed. So identify them via RepositoryUrl:
+                            || (m.Key = "RepositoryUrl" && m.Value.StartsWith "https://github.com/dotnet/"))
 
                     if not isFramework then
                         None

--- a/src/app/Fake.Runtime/Environment.fs
+++ b/src/app/Fake.Runtime/Environment.fs
@@ -73,5 +73,21 @@ let inline internal fakeContextAssembly () =
 /// Gets the FAKE version no.
 let fakeVersion = fakeContextAssembly().GetName().Version.ToString()
 
+let getPlatform () =
+    match System.Reflection.Assembly.GetExecutingAssembly() with
+    | null -> ""
+    | x ->
+        match x.GetCustomAttributes(typeof<System.Runtime.Versioning.TargetFrameworkAttribute>, false) with
+        | null -> ""
+        | itms when itms.Length > 0 ->
+            (itms |> Seq.head :?> System.Runtime.Versioning.TargetFrameworkAttribute)
+                .FrameworkName
+        | _ -> ""
+
 /// Gets the FAKE Version string
-let fakeVersionStr = sprintf "FAKE 6 - F# Make (%s)" fakeVersion
+let fakeVersionStr =
+    sprintf
+        "FAKE %i - F# Make (%s) (running on %s)"
+        (fakeContextAssembly().GetName().Version.Major)
+        fakeVersion
+        (getPlatform ())

--- a/src/app/Fake.netcore/Fake.netcore.fsproj
+++ b/src/app/Fake.netcore/Fake.netcore.fsproj
@@ -8,7 +8,7 @@
     <AssemblyName>fake</AssemblyName>
     <OutputType>Exe</OutputType>
     <NoWarn>FS3186</NoWarn>
-    <RuntimeIdentifiers>win7-x86;win7-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/legacy/[ignored].gitlab-ci.yml
+++ b/src/legacy/[ignored].gitlab-ci.yml
@@ -64,8 +64,8 @@ do_build:
 #    mkdir fake-bin
 #    unzip -n artifacts/fake-dotnetcore-ubuntu.14.04-x64.zip -d fake-bin || echo unzip returned $?
 #    chmod +x fake-bin/fake
-#    mkdir -p nuget/dotnetcore/Fake.netcore/win7-x86
-#    unzip -n artifacts/fake-dotnetcore-win7-x86.zip -d nuget/dotnetcore/Fake.netcore/win7-x86 || echo unzip returned $?
+#    mkdir -p nuget/dotnetcore/Fake.netcore/win-x86
+#    unzip -n artifacts/fake-dotnetcore-win-x86.zip -d nuget/dotnetcore/Fake.netcore/win-x86 || echo unzip returned $?
 #    unzip -n artifacts/chocolatey-requirements.zip || echo unzip returned $?
 #    export artifactsdirectory=$PWD/artifacts
 #    fake-bin/fake build target DotNetCoreCreateChocolateyPackage


### PR DESCRIPTION
Updated expired runtime-identifiers to current version:
https://learn.microsoft.com/en-us/dotnet/core/rid-catalog#known-rids

Added few explicit types to places where .NET8 will have multiple overloads so compiler won't be able to pick correct types.

Addressed the issue detecting .NET-assemblies in the future, pointed out here: https://github.com/fsprojects/FAKE/pull/2818#issuecomment-2356617433
