### PR TITLE
Set PublishReferencesDocumentationFiles=false in fake-cli

### DIFF
--- a/src/app/fake-cli/fake-cli.fsproj
+++ b/src/app/fake-cli/fake-cli.fsproj
@@ -11,6 +11,7 @@
         <PostInstallScript>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)/debian-postinst.sh'))</PostInstallScript>
         <NoWarn>FS3186</NoWarn>
         <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+        <PublishReferencesDocumentationFiles>false</PublishReferencesDocumentationFiles>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Description

Just a thought when looking at the build output for fake-cli - Is there a need to have the XML documentation files for a bunch of the FAKE libraries included in the fake-cli NuGet package?

e.g.
![image](https://github.com/user-attachments/assets/e3c6b805-35be-4bb0-b104-103f437bf88c)

