### PR TITLE
ResolveDotNetRoots to support resoving multiple .NET version paths

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 ## 6.1.2 - 2024-09-20
 * Runtime-identifier update to more recent runtimes.
 * Removed .NETFrameworkAssembly attribute fix on detecting .NET assemblies.
+* SdkAssemblyResolver: Support detecting multiple .NET paths.
 
 ## 6.1.1 - 2024-08-30
 * BUGFIX: Assembly resolver to pick a found SDK instead of first SDK, thanks @Thorium - https://github.com/fsprojects/FAKE/pull/2797/files

--- a/src/app/Fake.Runtime/SdkAssemblyResolver.fs
+++ b/src/app/Fake.Runtime/SdkAssemblyResolver.fs
@@ -341,10 +341,11 @@ type SdkAssemblyResolver(logLevel: Trace.VerboseLevel) =
                 releases
                 |> Seq.map (fun release -> release.Runtime.Version.ToString())
                 |> Seq.distinct
+                |> Seq.toList
 
             if this.LogLevel.PrintVerbose then
                 versions
-                |> Seq.iter (fun version -> Trace.trace $"Resolved runtime version: {version}")
+                |> List.iter (fun version -> Trace.trace $"Resolved runtime version: {version}")
 
             versions
 

--- a/src/app/Fake.Runtime/SdkAssemblyResolver.fs
+++ b/src/app/Fake.Runtime/SdkAssemblyResolver.fs
@@ -316,8 +316,8 @@ type SdkAssemblyResolver(logLevel: Trace.VerboseLevel) =
                 [ DotNet.getVersion (versionOptions None) |> ReleaseVersion ]
             else
                 dotnetRoots
-                |> Array.map (fun dotnetRoot -> DotNet.getVersion (versionOptions (Some dotnetRoot)) |> ReleaseVersion)
-                |> Array.toList
+                |> Seq.map (fun dotnetRoot -> DotNet.getVersion (versionOptions (Some dotnetRoot)) |> ReleaseVersion)
+                |> Seq.toList
 
         let productReleases =
             sdkVersions
@@ -339,12 +339,12 @@ type SdkAssemblyResolver(logLevel: Trace.VerboseLevel) =
         | releases ->
             let versions =
                 releases
-                |> List.map (fun release -> release.Runtime.Version.ToString())
-                |> List.distinct
+                |> Seq.map (fun release -> release.Runtime.Version.ToString())
+                |> Seq.distinct
 
             if this.LogLevel.PrintVerbose then
                 versions
-                |> List.iter (fun version -> Trace.trace $"Resolved runtime version: {version}")
+                |> Seq.iter (fun version -> Trace.trace $"Resolved runtime version: {version}")
 
             versions
 


### PR DESCRIPTION
There is still an existing issue with `ResolveDotNetRoot` that it fetches the first .NET version from the computer, which might or might not be the intended version to be used. This happens if the folder doesn't have pre-fixed global.json.

This commit adds `ResolveDotNetRoots` which instead returns array of found version.
Then the SdkAssemblyResolver can work better in a computer where there are multiple .NET versions installed.


