### PR TITLE
Yet another SdkAssemblyResolver fix

### DIFF
--- a/src/app/Fake.Runtime/SdkAssemblyResolver.fs
+++ b/src/app/Fake.Runtime/SdkAssemblyResolver.fs
@@ -294,7 +294,22 @@ type SdkAssemblyResolver(logLevel: Trace.VerboseLevel) =
 
         match net60releases with
         | None -> []
-        | Some versions -> versions |> List.filter sdkRelease
+        | Some versions ->
+            match versions |> List.filter sdkRelease with
+            | [] ->
+
+                Trace.traceFAKE $"No exact match of product releases {version.ToString()} found."
+
+                match versions |> List.filter (fun release -> release.Version.Major = version.Major) with
+                | [] ->
+                    Trace.traceFAKE
+                        $"No product release found for {version.ToString()}. Maybe a pre-release? Returning all the versions."
+
+                    versions
+                | majorMatch ->
+                    Trace.traceFAKE $".NET {version.Major} product releases returned."
+                    majorMatch
+            | foundMatch -> foundMatch
 
     member this.GetProductReleaseForSdk(version: ReleaseVersion) =
         this.GetProductReleasesForSdk version |> List.tryHead


### PR DESCRIPTION
After this PR you can build Fake with a computer that has .NET 9 RC installed, without any global.json hacks:
Global.json is for the product itself, not for FAKE, so having to fix it to .NET 6 is bad idea.

SDKAssemblyResolver tries to match the SDK versions (`dotnet --version`) to runtime versions (`dotnet --list-runtimes`).
There is no product release for .NET9, so the search of runtime of SDK 9.0.100-rc.1.24452.12 never matched.

After this PR, it will say, ok SDK 9.0.100-rc.1.24452.12 not found, let's see what you have in your computer... And then respecting the FAKE_SDK_RESOLVER_CUSTOM_DOTNET_VERSION build with latest found runtime (they are in descending release-order by default). So by default FAKE 6 will build on .NET6 which should be totally fine because FAKE is just a wrapper over other tools like dotnet.exe, so hopefully it can still build .NET8 (and 9) software if you just have the latest dotnet.exe.
