### PR TITLE
Publish unit test results for pull request builds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,6 +4,16 @@ on:
     [push, pull_request]
 
 jobs:
+    event_file: # Used for test reporting
+      name: "Publish event file"
+      runs-on: ubuntu-latest
+      steps:
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: EventFile
+          path: ${{ github.event_path }}
+
     build:
 
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,3 +31,9 @@ jobs:
               with:
                   name: fake-artifacts-${{ matrix.os }}
                   path: release/artifacts
+            - name: publish test results
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: test-results-${{ matrix.os }}
+                  path: testresults

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,0 +1,47 @@
+# This is used to publish test results to PRs so that we can support external forks
+
+name: Publish FAKE Test Results
+
+on:
+    workflow_run:
+      workflows: ["FAKE Build and Test"]
+      types:
+        - completed
+permissions: {}
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    permissions:
+      checks: write
+      pull-requests: write
+      actions: read
+
+    steps:
+      # Download the Github event file
+      - name: Download Event file
+        uses: dawidd6/action-download-artifact@v4
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          path: artifacts
+          name: EventFile
+
+      # Download all the test results files
+      - name: Download test results
+        uses: dawidd6/action-download-artifact@v4
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          path: test-results
+          pattern: test-results-*
+
+      # Publish the test report
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "test-results/**/*.xml"

--- a/build.fsx
+++ b/build.fsx
@@ -393,8 +393,10 @@ let callPaket wd args =
 /// <param name="dllPath">Test assembly to run tests from</param>
 /// <param name="resultsXml">Expecto test results XML file</param>
 let runExpecto workDir dllPath resultsXml =
+    let resultsFile = "testresults" </> resultsXml
+
     let processResult =
-        DotNet.exec (dotnetWorkingDir workDir) (sprintf "%s" dllPath) (sprintf "--nunit-summary %s" resultsXml)
+        DotNet.exec (dotnetWorkingDir workDir) (sprintf "%s" dllPath) (sprintf "--nunit-summary %s" resultsFile)
 
     if processResult.ExitCode <> 0 then
         failwithf "Tests in %s failed." (Path.GetFileName dllPath)


### PR DESCRIPTION
Based on comments in #2818 - publish the unit test results files during CI builds, and then publish a test report using https://github.com/EnricoMi/publish-unit-test-result-action.

This first attempt is based on the action documentation, and on some implementations in other repositories (This is the first time I've used it myself)

Note: It appears that Github won't pick up the new publish-test-results action until the yaml file for it is in the master branch, so I've had to merge a test change into the master branch in my fork to test it - you can see the results for that at https://github.com/Numpsy/FAKE/runs/30818769728 which looks reasonable.

Not sure if it'll need tuning to control where the test results get pushed to - e.g. if they get displayed inline inside pull requests as well as in the build results page.
