### PR TITLE
Remove links to https://forge.run from the documentation

### DIFF
--- a/docs/_template.html
+++ b/docs/_template.html
@@ -276,8 +276,6 @@
                             <li class="border-b"><a class="hover:text-[#d4b43c]" href="https://fsharp.org/">F#</a></li>
                             <li class="border-b"><a class="hover:text-[#d4b43c]" href="https://ionide.io/">Ionide</a>
                             </li>
-                            <li class="border-b"><a class="hover:text-[#d4b43c]" href="https://forge.run/">Forge</a>
-                            </li>
                         </ul>
                     </div>
                 </div>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -213,7 +213,6 @@
                             <li class="border-b"><a class="hover:text-[#d4b43c]" href="https://fsharp.org/">F#</a></li>
                             <li class="border-b"><a class="hover:text-[#d4b43c]" href="https://ionide.io/">Ionide</a>
                             </li>
-                            <li class="border-b"><a class="hover:text-[#d4b43c]" href="https://forge.run/">Forge</a></li>
                         </ul>
                     </div>
                 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -306,8 +306,6 @@
                             <li class="border-b"><a class="hover:text-[#d4b43c]" href="https://fsharp.org/">F#</a></li>
                             <li class="border-b"><a class="hover:text-[#d4b43c]" href="https://ionide.io/">Ionide</a>
                             </li>
-                            <li class="border-b"><a class="hover:text-[#d4b43c]" href="https://forge.run/">Forge</a>
-                            </li>
                         </ul>
                     </div>
                 </div>

--- a/docs/reference/_template.html
+++ b/docs/reference/_template.html
@@ -236,7 +236,6 @@
                             Formatting</a></li>
                         <li class="border-b"><a class="hover:text-[#d4b43c]" href="https://fsharp.org/">F#</a></li>
                         <li class="border-b"><a class="hover:text-[#d4b43c]" href="https://ionide.io/">Ionide</a></li>
-                        <li class="border-b"><a class="hover:text-[#d4b43c]" href="https://forge.run/">Forge</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
I don't know all the history of this, but - 
As it stands, the fake.build site has links to https://forge.run in the page footers - 

![image](https://github.com/user-attachments/assets/8c1cdafa-95f6-42dd-8da2-ffc0796ac87f)

If I follow that link, it goes to a 'domain for sale' page. 
So - is there a point in keeping the link there?

The github pages are still up at https://github.com/ionide/Forge but the project is archived, so it doesn't seem useful linking to that either.

