### PR TITLE
Change the `global.json` parsing in `Fake.Dotnet.Cli` to use System.Text.Json instead of Newtonsoft.Json

### DIFF
--- a/src/app/Fake.DotNet.Cli/paket.references
+++ b/src/app/Fake.DotNet.Cli/paket.references
@@ -2,6 +2,5 @@ group fakemodule
 
 FSharp.Core
 NETStandard.Library
-Newtonsoft.Json
 // https://stackoverflow.com/questions/58326739/how-can-i-find-the-target-of-a-linux-symlink-in-c-sharp
 Mono.Posix.NETStandard


### PR DESCRIPTION
### Description

refs comments in https://github.com/fsprojects/FAKE/pull/2825 about using System.Text.Json rather than Newtonsoft.Json

## TODO

- The .NET 6.0(+) builds can use the inbox version of System.Text.Json, but the .NET Standard 2.0 build needs the NuGet package. As it stands, the package reference is transitive rather than direct.
- The code aorund here is called indirectly by the unit tests for Fake.Dotnet.Cli but I don't *think* there is anything direct for the global.json parsing (maybe there could be, to test things like json comment handling or issues like https://github.com/fsprojects/FAKE/issues/2803)
