### PR TITLE
Fix documentation articles links

### DIFF
--- a/docs/data.json
+++ b/docs/data.json
@@ -608,7 +608,7 @@
         {
             "title": "Sign Files using SignTool",
             "description": "Digitally signs files, verifies signatures in files, or time stamps files",
-            "href": "/articles/fake-signtool.html"
+            "href": "/articles/tools-signtool.html"
         },
         {
             "title": "Releasifying NuGet Packages with Squirrel",

--- a/src/app/Fake.DotNet.NuGet/NuGet.fs
+++ b/src/app/Fake.DotNet.NuGet/NuGet.fs
@@ -3,7 +3,7 @@ namespace Fake.DotNet.NuGet
 /// <summary>
 /// Contains helper functions and task which allow to inspect, create and publish
 /// <a href="https://www.nuget.org/">NuGet</a> packages.
-/// There is also a tutorial about <a href="/dotnet-nuget.html">nuget package creating</a> available.
+/// There is also a tutorial about <a href="/articles/dotnet-nuget.html">nuget package creating</a> available.
 /// </summary>
 module NuGet =
 

--- a/src/app/Fake.DotNet.NuGet/Restore.fs
+++ b/src/app/Fake.DotNet.NuGet/Restore.fs
@@ -5,7 +5,7 @@ namespace Fake.DotNet.NuGet
 /// <a href="http://www.nuget.org">nuget.org</a> using the
 /// <a href="https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-restore">
 /// nuget.exe restore command</a>. There is also a tutorial about
-/// <a href="/dotnet-nuget.html">nuget package restore</a> available.
+/// <a href="/articles/dotnet-nuget.html">nuget package restore</a> available.
 /// </summary>
 module Restore =
 


### PR DESCRIPTION
### Description

- Fixed link to documentation article "Sign Files using SignTool" (/articles/tools-signtool.html).
- Fixed links to documentation article "Managing Dependencies using NuGet" (/articles/dotnet-nuget.html).
