### PR TITLE
Discover VSTest and MSTest using VSWhere

### DIFF
--- a/src/app/Fake.DotNet.Testing.MSTest/MSTest.fs
+++ b/src/app/Fake.DotNet.Testing.MSTest/MSTest.fs
@@ -8,20 +8,14 @@ module MSTest =
 
     open System
     open System.Text
+    open BlackFox.VsWhere
     open Fake.Core
+    open Fake.IO
     open Fake.Testing.Common
-
-    let internal mstestPaths =
-        [| @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\"
-           @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Professional\Common7\IDE\"
-           @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Community\Common7\IDE\"
-           @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\"
-           @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Professional\Common7\IDE\"
-           @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Community\Common7\IDE\"
-           @"[ProgramFilesX86]\Microsoft Visual Studio 14.0\Common7\IDE"
-           @"[ProgramFilesX86]\Microsoft Visual Studio 12.0\Common7\IDE"
-           @"[ProgramFilesX86]\Microsoft Visual Studio 11.0\Common7\IDE"
-           @"[ProgramFilesX86]\Microsoft Visual Studio 10.0\Common7\IDE" |]
+    
+    let private getAllVsPath () =
+        VsInstances.getWithPackage "Microsoft.VisualStudio.PackageGroup.TestTools.MSTestV2.Managed" false
+        |> List.map (fun vs -> Path.combine vs.InstallationPath "Common7\\Tools")
 
     let internal msTestExe =
         if Environment.isWindows then
@@ -86,7 +80,7 @@ module MSTest =
           Tests = []
           TimeOut = TimeSpan.FromMinutes 5.
           ToolPath =
-            match ProcessUtils.tryFindLocalTool "TOOL" msTestExe mstestPaths with
+            match ProcessUtils.tryFindLocalTool "TOOL" msTestExe (getAllVsPath ()) with
             | Some path -> path
             | None -> ""
           Details = []

--- a/src/app/Fake.DotNet.Testing.MSTest/MSTest.fs
+++ b/src/app/Fake.DotNet.Testing.MSTest/MSTest.fs
@@ -12,7 +12,7 @@ module MSTest =
     open Fake.Core
     open Fake.IO
     open Fake.Testing.Common
-    
+
     let private getAllVsPath () =
         VsInstances.getWithPackage "Microsoft.VisualStudio.PackageGroup.TestTools.MSTestV2.Managed" false
         |> List.map (fun vs -> Path.combine vs.InstallationPath "Common7\\Tools")

--- a/src/app/Fake.DotNet.Testing.MSTest/paket.references
+++ b/src/app/Fake.DotNet.Testing.MSTest/paket.references
@@ -2,3 +2,4 @@ group fakemodule
 
 FSharp.Core
 NETStandard.Library
+BlackFox.VsWhere

--- a/src/app/Fake.DotNet.Testing.VSTest/VSTest.fs
+++ b/src/app/Fake.DotNet.Testing.VSTest/VSTest.fs
@@ -15,6 +15,7 @@ module VSTest =
 
     let private guessVSTestPaths () =
         let vsTestRelativePath = @"Common7\IDE\CommonExtensions\Microsoft\TestWindow"
+
         VsInstances.getAll ()
         |> List.map (fun vs -> Fake.IO.Path.combine vs.InstallationPath vsTestRelativePath)
 

--- a/src/app/Fake.DotNet.Testing.VSTest/VSTest.fs
+++ b/src/app/Fake.DotNet.Testing.VSTest/VSTest.fs
@@ -2,6 +2,7 @@
 
 open Fake.Core
 open Fake.Testing.Common
+open BlackFox.VsWhere
 open System
 open System.IO
 open System.Text
@@ -12,14 +13,10 @@ open System.Text
 [<RequireQualifiedAccess>]
 module VSTest =
 
-    let private vsTestPaths =
-        [| @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
-           @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
-           @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
-           @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
-           @"[ProgramFilesX86]\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
-           @"[ProgramFilesX86]\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
-           @"[ProgramFilesX86]\Microsoft Visual Studio 11.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow" |]
+    let private guessVSTestPaths () =
+        let vsTestRelativePath = @"Common7\IDE\CommonExtensions\Microsoft\TestWindow"
+        VsInstances.getAll ()
+        |> List.map (fun vs -> Fake.IO.Path.combine vs.InstallationPath vsTestRelativePath)
 
     let private vsTestExe =
         if Environment.isMono then
@@ -115,7 +112,7 @@ module VSTest =
           ListLoggers = false
           ListSettingsProviders = false
           ToolPath =
-            match ProcessUtils.tryFindFile vsTestPaths vsTestExe with
+            match ProcessUtils.tryFindFile (guessVSTestPaths ()) vsTestExe with
             | Some path -> path
             | None -> ""
           WorkingDir = null

--- a/src/app/Fake.DotNet.Testing.VSTest/VSTest.fs
+++ b/src/app/Fake.DotNet.Testing.VSTest/VSTest.fs
@@ -13,7 +13,10 @@ open System.Text
 module VSTest =
 
     let private vsTestPaths =
-        [| @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
+        [| @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
+           @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
+           @"[ProgramFilesX86]\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
+           @"[ProgramFilesX86]\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
            @"[ProgramFilesX86]\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
            @"[ProgramFilesX86]\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow"
            @"[ProgramFilesX86]\Microsoft Visual Studio 11.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow" |]

--- a/src/app/Fake.DotNet.Testing.VSTest/paket.references
+++ b/src/app/Fake.DotNet.Testing.VSTest/paket.references
@@ -2,3 +2,4 @@ group fakemodule
 
 FSharp.Core
 NETStandard.Library
+BlackFox.VsWhere


### PR DESCRIPTION
Fake.DotNet.Testing.VSTest and Fake.DotNet.Testing.MSTest currently search for VSTest and MSTest respectively using hard-coded lists of possible paths. These paths are simply different versions of Visual Studio.

@robertpi previously did work to update these paths and partially move them to a VSWhere for locating Visual Studio installs.
The work was not merged. #2542 

This PR rebases #2542 and further migrates VSTest discovery to use VSWhere.

This should reduce effort to keep Fake.DotNet.Testing.VSTest and Fake.DotNet.Testing.MSTest up to date as new versions of Visual Studio are released.

This PR will also fix the current issue where Fake.DotNet.Testing.VSTest cannot automatically discover VSTest with recent versions of Visual Studio.

Note that VSWhere [only works for VisualStudio 2017+](https://github.com/vbfox/FoxSharp/tree/master/src/BlackFox.VsWhere). We'll want to re-add hard-coded pre-2017 paths if we want to continue supporting those older versions of Visual Studio

@xperiandri 