### PR TITLE
Fix the test result output path for TemplateIntegrationTests

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -664,11 +664,10 @@ Target.create "DotNetCoreIntegrationTests" (fun _ ->
         "Fake_Core_IntegrationTests.TestResults.xml")
 
 Target.create "TemplateIntegrationTests" (fun _ ->
-    let targetDir = srcDir </> "test" </> "Fake.DotNet.Cli.IntegrationTests"
 
     runExpecto
-        targetDir
-        "bin/Release/net6.0/Fake.DotNet.Cli.IntegrationTests.dll"
+        root
+        ("src" </> "test" </> "Fake.DotNet.Cli.IntegrationTests" </> "bin" </> "Release" </> "net6.0" </> "Fake.DotNet.Cli.IntegrationTests.dll")
         "Fake_DotNet_Cli_IntegrationTests.TestResults.xml"
     
     Shell.rm_rf (root </> "test"))


### PR DESCRIPTION
### Description

I noticed when having a poke at the .NET 8 CI test failures that the 'Fake.DotNet.Cli.IntegrationTests' test results file isn't being published into the CI as the restults file is getting put under the integration tests folder rather than under the root results folder with the other 3 result xml files - so this is an attempt to fix that by using the same root results folder as the other test project runs