### PR TITLE
Fix sprintf format in TemplateTests::getDebuggingInfo

### DIFF
--- a/src/test/Fake.DotNet.Cli.IntegrationTests/TemplateTests.fs
+++ b/src/test/Fake.DotNet.Cli.IntegrationTests/TemplateTests.fs
@@ -56,7 +56,7 @@ let inline redirect () =
 
 let getDebuggingInfo () =
     sprintf
-        "%s\nDOTNET_ROOT: %s\nPATH: %s\n"
+        "\nDOTNET_ROOT: %s\nPATH: %s\n"
         (Environment.GetEnvironmentVariable("DOTNET_ROOT"))
         (Environment.GetEnvironmentVariable "PATH")
 


### PR DESCRIPTION
When looking at the remaining test failures when running on .NET 8 I noticed that some of the test error messages contained

...Debugging Info: Fake.DotNet.Cli.IntegrationTests.TemplateTests+getDebuggingInfo@58-2 Result: ...

and I think that '+getDebuggingInfo' is because the sprintf in getDebuggingInfo contains 3 %s but only two parameters, so it's actually being treated as a partially applied function by the string interpolcation in isProcessSucceeded rather than a string?

Looks like it's been like that for some time - not sure what the original intent was
