### PR TITLE
Fix some 'Pattern discard is not allowed for union case that takes no data' build warnings

### DIFF
--- a/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
+++ b/src/app/Fake.BuildServer.TeamCity/TeamCity.fs
@@ -35,7 +35,7 @@ module TeamCityImportExtensions =
             | ImportData.Junit -> "junit"
             | ImportData.FxCop -> "FxCop"
             | ImportData.Nunit _ -> "nunit"
-            | ImportData.Xunit _ -> "nunit"
+            | ImportData.Xunit -> "nunit"
 
 ///<summary>
 /// Native support for TeamCity specific APIs.

--- a/src/app/Fake.BuildServer.TeamFoundation/TeamFoundation.fs
+++ b/src/app/Fake.BuildServer.TeamFoundation/TeamFoundation.fs
@@ -408,10 +408,10 @@ module TeamFoundation =
                         | TagStatus.Failed -> "Failed", "ERROR"
 
                     setBuildState vsoState msg
-                | TraceData.ImportData (ImportData.Junit _, path) -> publishTests "JUnit" [ path ] false "" "" "" true
+                | TraceData.ImportData (ImportData.Junit, path) -> publishTests "JUnit" [ path ] false "" "" "" true
                 | TraceData.ImportData (ImportData.Nunit _, path) -> publishTests "NUnit" [ path ] false "" "" "" true
-                | TraceData.ImportData (ImportData.Mstest _, path) -> publishTests "VSTest" [ path ] false "" "" "" true
-                | TraceData.ImportData (ImportData.Xunit _, path) -> publishTests "XUnit" [ path ] false "" "" "" true
+                | TraceData.ImportData (ImportData.Mstest, path) -> publishTests "VSTest" [ path ] false "" "" "" true
+                | TraceData.ImportData (ImportData.Xunit, path) -> publishTests "XUnit" [ path ] false "" "" "" true
                 | TraceData.ImportData (ImportData.BuildArtifactWithName name, path) ->
                     publishArtifactIfOk name (Some name) path
                 | TraceData.ImportData (typ, path) -> publishArtifactIfOk typ.Name (Some "fake-artifacts") path


### PR DESCRIPTION
These show up in the .NET 8 build

### Description

fixes
![image](https://github.com/user-attachments/assets/80b1ee7e-3968-4aee-a73b-6c39c4b928bc)
