### PR TITLE
Set the Ubuntu CI builds back to ubuntu-22.04

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,7 +19,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ubuntu-latest, windows-latest, macOS-13]
+                os: [ubuntu-22.04, windows-latest, macOS-13]
         steps:
             - uses: actions/checkout@v4
             - name: Setup .NET 6


### PR DESCRIPTION
### Description

Several of the unit tests have started failing in the CI on the Ubuntu runner with the error
```
trying to start a .NET process on a non-windows platform, but mono could not be found. Try to set the MONO environment variable or add mono to the PATH.
```

Which I guess is down to the 'latest' runner having rolled forward to Ubuntu 24.04, which according to https://github.com/actions/runner-images/issues/10636 no longer has Mono installed by default.

Possibly the build could be changed to install Mono itself - I haven't looked in to trying it.