### PR TITLE
Add Telegram Bot API support to FAKE

### DIFF
--- a/Fake.sln
+++ b/Fake.sln
@@ -195,6 +195,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fake.JavaScript.TypeScript"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fake.DotNet.Fsdocs", "src\app\Fake.DotNet.Fsdocs\Fake.DotNet.Fsdocs.fsproj", "{6918A236-3F2A-47EA-9651-020522C48E24}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fake.Api.TelegramBot", "src\app\Fake.Api.TelegramBot\Fake.Api.TelegramBot.fsproj", "{D44BBF46-1490-4249-9D25-C7DF77039EE0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1248,6 +1250,18 @@ Global
 		{6918A236-3F2A-47EA-9651-020522C48E24}.Release|x64.Build.0 = Release|Any CPU
 		{6918A236-3F2A-47EA-9651-020522C48E24}.Release|x86.ActiveCfg = Release|Any CPU
 		{6918A236-3F2A-47EA-9651-020522C48E24}.Release|x86.Build.0 = Release|Any CPU
+		{D44BBF46-1490-4249-9D25-C7DF77039EE0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D44BBF46-1490-4249-9D25-C7DF77039EE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D44BBF46-1490-4249-9D25-C7DF77039EE0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D44BBF46-1490-4249-9D25-C7DF77039EE0}.Debug|x64.Build.0 = Debug|Any CPU
+		{D44BBF46-1490-4249-9D25-C7DF77039EE0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D44BBF46-1490-4249-9D25-C7DF77039EE0}.Debug|x86.Build.0 = Debug|Any CPU
+		{D44BBF46-1490-4249-9D25-C7DF77039EE0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D44BBF46-1490-4249-9D25-C7DF77039EE0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D44BBF46-1490-4249-9D25-C7DF77039EE0}.Release|x64.ActiveCfg = Release|Any CPU
+		{D44BBF46-1490-4249-9D25-C7DF77039EE0}.Release|x64.Build.0 = Release|Any CPU
+		{D44BBF46-1490-4249-9D25-C7DF77039EE0}.Release|x86.ActiveCfg = Release|Any CPU
+		{D44BBF46-1490-4249-9D25-C7DF77039EE0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1341,6 +1355,7 @@ Global
 		{5472237F-020B-4F9A-8E06-01D553576387} = {7BFFAE76-DEE9-417A-A79B-6A6644C4553A}
 		{1C476373-FF62-4EA7-8CCC-6A0D0DB96B6D} = {7BFFAE76-DEE9-417A-A79B-6A6644C4553A}
 		{6918A236-3F2A-47EA-9651-020522C48E24} = {7BFFAE76-DEE9-417A-A79B-6A6644C4553A}
+		{D44BBF46-1490-4249-9D25-C7DF77039EE0} = {7BFFAE76-DEE9-417A-A79B-6A6644C4553A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {058A0C5E-2216-4306-8AFB-0AE28320C26A}

--- a/docs/articles/api-telegram-bot.md
+++ b/docs/articles/api-telegram-bot.md
@@ -1,0 +1,66 @@
+# Sending Notifications to a Telegram Bot API
+
+In this article, you will learn how to send notifications using the [Telegram](https://telegram.org) Bot API in FAKE.
+This assumes you already have a Telegram bot set up.
+
+## Creating a Telegram Bot & Obtaining API Credentials
+
+Before sending messages, you need to create a Telegram bot and obtain an API token
+
+# 1. Step 1: Create a Telegram Bot
+1. Open Telegram and search for @BotFather
+2. Start a chat and use the command /newbot.
+3. Follow the instructions to name your bot and set a username.
+4. Once created, BotFather will provide you with a Bot Token, which looks like:
+
+```makefile
+715689912:AAeExvzsJsdfgggsasgagagaagjyuyE9_aZGEv
+```
+
+# 2. Step 2: Obtain the Chat ID
+
+To send messages, you need the Chat ID where messages will be sent.
+
+1. Send any message to your bot.
+2. Call Telegram's getUpdates API using curl or a browser:
+
+    ```
+    curl "https://api.telegram.org/botYOUR_BOT_TOKEN/getUpdates"
+    ```
+
+3. Find the "chat" section in the response. The id value is your Chat ID.
+
+## Sending a Notification to Telegram
+
+The following sample FAKE target demonstrates how to send a message to a Telegram bot:
+
+```fsharp
+open Fake.Api
+
+// The bot token and chat ID obtained from BotFather and getUpdates
+
+let result =
+    TelegramBot.sendMessage (fun p ->
+        { p with
+            BotToken = "715689912:AAeExvzsJsdfgggsasgagagaagjyuyE9_aZGEv"
+            ChatId = "313916395"
+            Text = "```csharp\nstring msg = \"Hello, World!\";\n```"
+        })
+
+match result with
+| Ok _ -> printfn "✅ Message sent successfully"
+| Error c -> printfn $"❌ Couldn't send the message. HttpCode: {c}"
+```
+
+This example sends a formatted C# code block to Telegram using MarkdownV2.
+
+Expected Output
+Once executed, you should see the message appear in the specified Telegram chat, formatted as a code block:
+
+```csharp
+string msg = "Hello, World!";
+```
+
+By default, messages in FAKE’s Telegram Bot API module use MarkdownV2 for formatting.
+However, you can also use HTML formatting by setting ParseMode = Html. See for [details] (https://core.telegram.org/bots/api#formatting-options)
+

--- a/docs/data.json
+++ b/docs/data.json
@@ -240,6 +240,10 @@
                     "href": "/reference/fake-api-slack.html"
                 },
                 {
+                    "title": "TelegramBot",
+                    "href": "/reference/fake-api-telegram-bot.html"
+                },
+                {
                     "title": "GitHub",
                     "href": "/reference/fake-api-github.html"
                 }

--- a/src/app/Fake.Api.TelegramBot/Fake.Api.TelegramBot.fsproj
+++ b/src/app/Fake.Api.TelegramBot/Fake.Api.TelegramBot.fsproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <OutputType>Library</OutputType>
+    <AssemblyName>Fake.Api.TelegramBot</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TelegramBot.fs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);NETSTANDARD;USE_HTTPCLIENT</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+  </PropertyGroup>
+  <Import Project="..\..\..\.paket\Paket.Restore.targets" />
+</Project>

--- a/src/app/Fake.Api.TelegramBot/TelegramBot.fs
+++ b/src/app/Fake.Api.TelegramBot/TelegramBot.fs
@@ -1,0 +1,76 @@
+﻿namespace Fake.Api
+
+open System.Net.Http
+open System.Text
+open Newtonsoft.Json
+
+[<RequireQualifiedAccess>]
+module TelegramBot =
+    module private TgApiEndpoints =
+        [<Literal>]
+        let sendMessage = "https://api.telegram.org/bot%s/sendMessage"
+
+    type ParseMode =
+        | MarkdownV2
+        | Html
+
+        member this.toText() =
+            match this with
+            | MarkdownV2 -> "MarkdownV2"
+            | Html -> "HTML"
+
+    type MessageParams =
+        {
+          BotToken: string
+          ChatId: string
+          Text: string
+          ParseMode: ParseMode
+          DisableNotification: bool }
+        
+    let MessageParamsDefaults : MessageParams =
+        { BotToken = ""
+          ChatId = ""
+          Text = ""
+          ParseMode = MarkdownV2
+          DisableNotification = false
+          }
+        
+    let private validateParams messageParams =
+        if System.String.IsNullOrWhiteSpace messageParams.BotToken then
+            failwith "You must set BokToken value"
+            
+        if System.String.IsNullOrWhiteSpace messageParams.ChatId then
+            failwith "You must set ChatId value"
+            
+        if System.String.IsNullOrWhiteSpace messageParams.Text then
+            failwith "You must set Text value"
+            
+        messageParams
+
+    let asyncSendMessage messageParams =
+        async {
+            use httpClient = new HttpClient()
+
+            let body =
+                {| chat_id = messageParams.ChatId
+                   parse_mode = messageParams.ParseMode.toText ()
+                   disable_notification = messageParams.DisableNotification
+                   text = messageParams.Text |}
+
+            let json = JsonConvert.SerializeObject(body)
+            let url = sprintf TgApiEndpoints.sendMessage messageParams.BotToken
+            use jsonContent = new StringContent(json,Encoding.UTF8, "application/json");
+            let! response = httpClient.PostAsync(url, jsonContent) |> Async.AwaitTask
+
+            return
+                match response.IsSuccessStatusCode with
+                | true -> Ok()
+                | false -> Error(int response.StatusCode)
+        }
+
+    let sendMessage (setParams: MessageParams -> MessageParams) =
+        MessageParamsDefaults
+        |> setParams
+        |> validateParams
+        |> asyncSendMessage
+        |> Async.RunSynchronously

--- a/src/app/Fake.Api.TelegramBot/paket.references
+++ b/src/app/Fake.Api.TelegramBot/paket.references
@@ -1,0 +1,5 @@
+group fakemodule
+
+FSharp.Core
+NETStandard.Library
+Newtonsoft.Json


### PR DESCRIPTION
### Description

This PR introduces a new API module, Fake.Api.Telegram, allowing FAKE to send messages via Telegram Bot API.
This enables FAKE users to integrate Telegram notifications into CI/CD pipelines.

Fixes: N/A (no related issue, but can be linked if necessary)

## TODO

New API documentation added (Fake.Api.Telegram)
- [x] Module linked in the "side navigation" (docs/data.json)
- [x] Module placed in the correct namespace (Fake.Api.TelegramBot)
- [x] Module added to Fake.sln (dotnet sln Fake.sln add src/app/Fake.Api.TelegramBot/Fake.Api.TelegramBot.fsproj)
- [x] Follows [FAKE API Design Guidelines](https://fake.build/guide/contributing.html#API-Design-Guidelines)
- [x] Unit or integration test **does not exist** because it requires a bot token, which is sensitive information and cannot be hardcoded in tests.
